### PR TITLE
update the clipboard translation

### DIFF
--- a/cndocs/clipboard.md
+++ b/cndocs/clipboard.md
@@ -38,7 +38,7 @@ async _getContent() {
 static setString(content)
 ```
 
-设置剪贴板的文本内容。返回一个`Promise`，然后你可以用下面的方式来设置剪贴板内容。
+设置剪贴板的文本内容，然后你可以用下面的方式来设置剪贴板内容。
 
 ```javascript
 _setContent() {


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

## 更新clipboard翻译,删除`setString`方法返回`promise`翻译

英文翻译
```
Set content of string type. You can use following code to set clipboard content
```
此处并没有提示说返回是`promise`，

源码也没有说setString方法返回的是`promise`
```
/**
 * Copyright (c) 2015-present, Facebook, Inc.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 *
 * @format
 * @flow strict-local
 */

'use strict';

const Clipboard = require('NativeModules').Clipboard;

/**
 * `Clipboard` gives you an interface for setting and getting content from Clipboard on both iOS and Android
 */
module.exports = {
  /**
   * Get content of string type, this method returns a `Promise`, so you can use following code to get clipboard content
   * ```javascript
   * async _getContent() {
   *   var content = await Clipboard.getString();
   * }
   * ```
   */
  getString(): Promise<string> {
    return Clipboard.getString();
  },
  /**
   * Set content of string type. You can use following code to set clipboard content
   * ```javascript
   * _setContent() {
   *   Clipboard.setString('hello world');
   * }
   * ```
   * @param the content to be stored in the clipboard.
   */
  setString(content: string) {
    Clipboard.setString(content);
  },
};

```
