### PR TITLE
Textinput/background/add

### DIFF
--- a/cndocs/textinput.md
+++ b/cndocs/textinput.md
@@ -80,7 +80,7 @@ export default class UselessTextInputMultiline extends Component {
 ```
 
 `TextInput`在安卓上默认有一个底边框，同时会有一些padding。如果要想使其看起来和iOS上尽量一致，则需要设置`padding: 0`，同时设置`underlineColorAndroid="transparent"`来去掉底边框，
-如果安卓上对TextInput的父级View设置backgroundColor但是TextInput背景色一直是白色额，那么也可以尝试设置这个属性
+如果安卓上对TextInput的父级View设置backgroundColor但是TextInput背景色一直是白色，那么也可以尝试设置这个属性
 
 又，在安卓上如果设置`multiline = {true}`，文本默认会垂直居中，可设置`textAlignVertical: 'top'`样式来使其居顶显示。
 

--- a/cndocs/textinput.md
+++ b/cndocs/textinput.md
@@ -79,7 +79,8 @@ export default class UselessTextInputMultiline extends Component {
 
 ```
 
-`TextInput`在安卓上默认有一个底边框，同时会有一些padding。如果要想使其看起来和iOS上尽量一致，则需要设置`padding: 0`，同时设置`underlineColorAndroid="transparent"`来去掉底边框。
+`TextInput`在安卓上默认有一个底边框，同时会有一些padding。如果要想使其看起来和iOS上尽量一致，则需要设置`padding: 0`，同时设置`underlineColorAndroid="transparent"`来去掉底边框，
+如果安卓上对TextInput的父级View设置backgroundColor但是TextInput背景色一直是白色额，那么也可以尝试设置这个属性
 
 又，在安卓上如果设置`multiline = {true}`，文本默认会垂直居中，可设置`textAlignVertical: 'top'`样式来使其居顶显示。
 


### PR DESCRIPTION
这次在小米8手机上使用textinput，发现无论如何也不能设置成功背景颜色，一直是白色，网上也没找到好的解决方案，underlineColorAndroid="transparent"`设置了这个属性才有效果，希望能让更多的人知道，谢谢