### PR TITLE
Update native-modules-ios.md

### DIFF
--- a/cndocs/native-modules-ios.md
+++ b/cndocs/native-modules-ios.md
@@ -212,7 +212,7 @@ CalendarManager.findEvents((error, events) => {
 我们把上面的代码用 promise 来代替回调进行重构：
 
 ```objectivec
-RCT_REMAP_METHOD(findEvents
+RCT_REMAP_METHOD(findEvents,
                  findEventsWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {


### PR DESCRIPTION
RCT_REMAP_METHOD 第一个参数后面缺少逗号

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
