### PR TITLE
修复 #994：恢复 cndocs 原标题（不改 title）

### DIFF
--- a/cndocs/alertios.md
+++ b/cndocs/alertios.md
@@ -1,6 +1,6 @@
 ---
 id: alertios
-title: '❌ AlertIOS'
+title: AlertIOS
 ---
 
 :::danger 已从 React Native 中移除

--- a/cndocs/animatedvaluexy.md
+++ b/cndocs/animatedvaluexy.md
@@ -1,6 +1,6 @@
 ---
 id: animatedvaluexy
-title: 动画.ValueXY
+title: Animated.ValueXY
 ---
 
 用于驱动 2D 动画的 2D 值，例如平移手势。与普通的 [`Animated.Value`](animatedvalue) 几乎相同的 API，但是是多路复用的。包含两个常规的“Animated.Value”。

--- a/cndocs/app-extensions.md
+++ b/cndocs/app-extensions.md
@@ -1,6 +1,6 @@
 ---
 id: app-extensions
-title: App Extensions
+title: iOS 应用小组件
 ---
 
 App Extensions 允许你在主应用之外提供自定义功能和内容。iOS 上有多种类型的 App Extensions，均在 [App Extension Programming Guide](https://developer.apple.com/library/content/documentation/General/Conceptual/ExtensibilityPG/index.html#//apple_ref/doc/uid/TP40014214-CH20-SW1) 中有所介绍。本指南将简要介绍如何在 iOS 上利用 App Extensions 的优势。

--- a/cndocs/appregistry.md
+++ b/cndocs/appregistry.md
@@ -1,6 +1,6 @@
 ---
 id: appregistry
-title: 应用程序注册中心
+title: AppRegistry
 ---
 
 <div className="banner-native-code-required">

--- a/cndocs/asyncstorage.md
+++ b/cndocs/asyncstorage.md
@@ -1,6 +1,6 @@
 ---
 id: asyncstorage
-title: '❌异步存储'
+title: 🚧 AsyncStorage
 ---
 
 :::危险已从 React Native 中移除

--- a/cndocs/backhandler.md
+++ b/cndocs/backhandler.md
@@ -1,6 +1,6 @@
 ---
 id: backhandler
-title: 返回处理程序
+title: BackHandler
 ---
 
 Backhandler API 检测用于后退导航的硬件按钮按下情况，允许您注册系统后退操作的事件侦听器，并允许您控制应用程序的响应方式。它仅适用于 Android。

--- a/cndocs/build-speed.md
+++ b/cndocs/build-speed.md
@@ -1,6 +1,6 @@
 ---
 id: build-speed
-title: 加快构建阶段
+title: 优化编译速度
 ---
 
 构建 React Native 应用程序可能**昂贵**并且需要开发人员花费几分钟的时间。

--- a/cndocs/building-for-tv.md
+++ b/cndocs/building-for-tv.md
@@ -1,6 +1,6 @@
 ---
 id: building-for-tv
-title: 🗑️ 电视设备构建
+title: 为电视和机顶盒制作应用
 hide_table_of_contents: true
 ---
 


### PR DESCRIPTION
本 PR 仅修复 #994 合并后带来的 cndocs frontmatter title 变更。\n\n规则：仅回滚 title，正文翻译内容保持不变。\n\n已按 #994 合并前版本逐文件恢复原标题。