### PR TITLE
docs(cndocs): sync fast-refresh URL (reactjs.org → react.dev)

### DIFF
--- a/cndocs/fast-refresh.md
+++ b/cndocs/fast-refresh.md
@@ -19,7 +19,7 @@ title: 快速刷新
 
 如果出现了**组件内部发生的运行时错误**，在你修复错误之后，快速刷新会话*也*将继续进行。在这种情况下，React 将会使用更新后的代码重新挂载你的应用。
 
-如果你在代码中使用了[error boundaries](https://zh-hans.reactjs.org/docs/error-boundaries.html)（这对于在生产环境中优雅地处理失败是一个好主意），它们将在红框之后的下一次编辑时重新尝试渲染。从这个意义上说，拥有错误边界可以防止您总是被踢出到根应用程序屏幕。然而，请记住错误边界不应该过于细粒度。它们由React在生产环境中使用，并且始终应该经过有意设计。
+如果你在代码中使用了[error boundaries](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)（这对于在生产环境中优雅地处理失败是一个好主意），它们将在红框之后的下一次编辑时重新尝试渲染。从这个意义上说，拥有错误边界可以防止您总是被踢出到根应用程序屏幕。然而，请记住错误边界不应该过于细粒度。它们由React在生产环境中使用，并且始终应该经过有意设计。
 
 ## 限制
 


### PR DESCRIPTION
## Summary

- 更新 `cndocs/fast-refresh.md` 中 error boundaries 链接，将过时的 `zh-hans.reactjs.org` URL 替换为上游的 `react.dev` 地址。

## 候选分析（sync-translations.sh 输出 22 个候选）

| 类别 | 数量 | 文件 |
|------|------|------|
| 已同步（误报） | 10 | colors, element-nodes, legacy/native-modules-ios, metro, profiling, signed-apk-android, text-nodes, the-new-architecture/* (3个) |
| 已移除组件 stub | 9 | checkbox, clipboard, datepickerandroid, datepickerios, imagepickerios, segmentedcontrolios, statusbarios, timepickerandroid, what-is-codegen |
| 跳过（CN 应保留旧版） | 1 | getting-started（CN 保留多平台搭建指南，不改为 Expo-first） |
| 实际无内容差异 | 1 | view-style-props（仅翻译差异，无内容漂移） |
| **实际更新** | **1** | **fast-refresh** |

## Test Plan
- [x] 仅修改 1 个文件，diff 确认无误
- [x] 未提交无关文件（chinese_files.txt 等）
- [x] PR 面向 production 分支

Closes (auto batch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated error boundaries documentation reference and added guidance on error boundary design practices, including retry behavior during development iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->