### PR TITLE
fix(cnwebsite): 修复 Docusaurus 3.10 编译 + 调整 getting-started 顺序

### DIFF
--- a/cndocs/getting-started.md
+++ b/cndocs/getting-started.md
@@ -11,6 +11,88 @@ import GuideLinuxAndroid from './\_getting-started-linux-android.md'; import Gui
 欢迎使用 React Native！这篇文档会帮助你搭建基本的 React Native 开发环境。
 
 <Tabs groupId="guide" defaultValue={constants.defaultGuide} values={constants.guides}>
+<TabItem value="native">
+
+根据你所使用的操作系统、针对的目标平台不同，具体步骤有所不同。如果想同时开发 iOS 和 Android 也没问题，你只需要先选一个平台开始，另一个平台的环境搭建只是稍有不同。
+
+如果`阅读完本文档`后还碰到很多环境搭建的问题，我们建议你还可以再看看[求助讨论区](https://github.com/reactnativecn/react-native-website/issues)。注意！视频教程或者其他网络上的博客和文章可能和本文档有所出入，请以最新版本的本文档所述为准！
+
+#### 开发平台
+
+<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
+<TabItem value="macos">
+
+#### 目标平台
+
+<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<TabItem value="android">
+
+[//]: # 'macOS, Android'
+
+<GuideMacOSAndroid/>
+
+</TabItem>
+<TabItem value="ios">
+
+[//]: # 'macOS, iOS'
+
+<GuideMacOSIOS/>
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="windows">
+
+#### 目标平台
+
+<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<TabItem value="android">
+
+[//]: # 'Windows, Android'
+
+<GuideWindowsAndroid/>
+
+</TabItem>
+<TabItem value="ios">
+
+[//]: # 'Windows, iOS'
+
+## 暂不支持
+
+> 苹果公司目前只允许在 Mac 电脑上开发 iOS 应用。如果你没有 Mac 电脑，那么只能考虑使用`沙盒环境`，或者先开发 Android 应用了。
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem value="linux">
+
+#### 目标平台
+
+<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
+<TabItem value="android">
+
+[//]: # 'Linux, Android'
+
+<GuideLinuxAndroid/>
+
+</TabItem>
+<TabItem value="ios">
+
+[//]: # 'Linux, iOS'
+
+## 暂不支持
+
+> 苹果公司目前只允许在 Mac 电脑上开发 iOS 应用。如果你没有 Mac 电脑，那么只能考虑使用`沙盒环境`，或者先开发 Android 应用了。
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+</Tabs>
+
+</TabItem>
 <TabItem value="quickstart">
 
 > 译注：沙盒环境大量依赖于国外网络环境，也不能直接安装第三方原生组件。不建议国内用户使用
@@ -103,88 +185,6 @@ If you know that you'll eventually need to include your own native code, Expo is
 Expo CLI configures your project to use the most recent React Native version that is supported by the Expo client app. The Expo client app usually gains support for a given React Native version about a week after the React Native version is released as stable. You can check [this document](https://docs.expo.io/versions/latest/sdk/overview/#sdk-version) to find out what versions are supported.
 
 If you're integrating React Native into an existing project, you'll want to skip Expo CLI and go directly to setting up the native build environment. Select "React Native CLI Quickstart" above for instructions on configuring a native build environment for React Native.
-
-</TabItem>
-<TabItem value="native">
-
-根据你所使用的操作系统、针对的目标平台不同，具体步骤有所不同。如果想同时开发 iOS 和 Android 也没问题，你只需要先选一个平台开始，另一个平台的环境搭建只是稍有不同。
-
-如果`阅读完本文档`后还碰到很多环境搭建的问题，我们建议你还可以再看看[求助讨论区](https://github.com/reactnativecn/react-native-website/issues)。注意！视频教程或者其他网络上的博客和文章可能和本文档有所出入，请以最新版本的本文档所述为准！
-
-#### 开发平台
-
-<Tabs groupId="os" defaultValue={constants.defaultOs} values={constants.oses} className="pill-tabs">
-<TabItem value="macos">
-
-#### 目标平台
-
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
-<TabItem value="android">
-
-[//]: # 'macOS, Android'
-
-<GuideMacOSAndroid/>
-
-</TabItem>
-<TabItem value="ios">
-
-[//]: # 'macOS, iOS'
-
-<GuideMacOSIOS/>
-
-</TabItem>
-</Tabs>
-
-</TabItem>
-<TabItem value="windows">
-
-#### 目标平台
-
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
-<TabItem value="android">
-
-[//]: # 'Windows, Android'
-
-<GuideWindowsAndroid/>
-
-</TabItem>
-<TabItem value="ios">
-
-[//]: # 'Windows, iOS'
-
-## 暂不支持
-
-> 苹果公司目前只允许在 Mac 电脑上开发 iOS 应用。如果你没有 Mac 电脑，那么只能考虑使用`沙盒环境`，或者先开发 Android 应用了。
-
-</TabItem>
-</Tabs>
-
-</TabItem>
-<TabItem value="linux">
-
-#### 目标平台
-
-<Tabs groupId="platform" defaultValue={constants.defaultPlatform} values={constants.platforms} className="pill-tabs">
-<TabItem value="android">
-
-[//]: # 'Linux, Android'
-
-<GuideLinuxAndroid/>
-
-</TabItem>
-<TabItem value="ios">
-
-[//]: # 'Linux, iOS'
-
-## 暂不支持
-
-> 苹果公司目前只允许在 Mac 电脑上开发 iOS 应用。如果你没有 Mac 电脑，那么只能考虑使用`沙盒环境`，或者先开发 Android 应用了。
-
-</TabItem>
-</Tabs>
-
-</TabItem>
-</Tabs>
 
 </TabItem>
 </Tabs>

--- a/cndocs/legacy/native-components-android.md
+++ b/cndocs/legacy/native-components-android.md
@@ -16,7 +16,7 @@ import NativeDeprecated from '../the-new-architecture/\_markdown_native_deprecat
 您还可以通过一个命令来配置生成包含原生组件的本地库模板。阅读[本地库设置](local-library-setup)指南以获取更多详细信息。
 :::
 
-## ImageView 示例 {#imageview-example}
+## ImageView 示例
 
 在这个例子里，我们来看看为了让 JavaScript 中可以使用 ImageView，需要做哪些准备工作。
 

--- a/cnwebsite/core/TabsConstants.tsx
+++ b/cnwebsite/core/TabsConstants.tsx
@@ -58,10 +58,10 @@ const jsDebuggers = [
 const defaultJsDebugger = 'flipper';
 
 const guides = [
-  {label: 'Expo Go Quickstart', value: 'quickstart'},
   {label: 'React Native CLI Quickstart', value: 'native'},
+  {label: 'Expo Go Quickstart', value: 'quickstart'},
 ];
-const defaultGuide = 'quickstart';
+const defaultGuide = 'native';
 
 const platforms = [
   {label: 'Android', value: 'android'},

--- a/cnwebsite/docusaurus.config.ts
+++ b/cnwebsite/docusaurus.config.ts
@@ -32,6 +32,7 @@ const isDeployPreview =
 const config: Config = {
   markdown: {
     mermaid: true,
+    format: 'detect',
   },
   themes: ['@docusaurus/theme-mermaid'],
   future: {

--- a/cnwebsite/sidebars.ts
+++ b/cnwebsite/sidebars.ts
@@ -24,7 +24,6 @@ export default {
     开发流程: [
       'running-on-device',
       'fast-refresh',
-      'metro',
       'libraries',
       'typescript',
       'strict-typescript-api',
@@ -84,11 +83,7 @@ export default {
       'profiling',
     ],
     'JavaScript 运行环境': ['javascript-environment', 'timers', 'hermes'],
-    Codegen: [
-      'the-new-architecture/what-is-codegen',
-      'the-new-architecture/using-codegen',
-      'the-new-architecture/codegen-cli',
-    ],
+    Codegen: ['the-new-architecture/codegen-cli'],
     原生开发: [
       {
         type: 'doc',
@@ -148,10 +143,6 @@ export default {
             type: 'doc',
             id: 'appendix',
             label: '附录',
-          },
-          {
-            type: 'doc',
-            id: 'the-new-architecture/create-module-library',
           },
         ],
       },

--- a/cnwebsite/versioned_docs/version-0.70/colors.md
+++ b/cnwebsite/versioned_docs/version-0.70/colors.md
@@ -53,8 +53,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 
 你还可以使用颜色名称来作为颜色值. React Native 遵循[CSS3 规范](http://www.w3.org/TR/css3-color/#svg-color)：
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.70/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.70/new-architecture-library-intro.md
@@ -54,8 +54,8 @@ export default (TurboModuleRegistry.get<Spec>('<MODULE_NAME>'): ?Spec);
 <TabItem value="TypeScript">
 
 ```ts
-import type { TurboModule } from 'react-native';
-import { TurboModuleRegistry } from 'react-native';
+import type {TurboModule} from 'react-native';
+import {TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   readonly getConstants: () => {};
@@ -102,8 +102,8 @@ export default (codegenNativeComponent<NativeProps>(
 <TabItem value="TypeScript">
 
 ```ts
-import type { ViewProps } from 'ViewPropTypes';
-import type { HostComponent } from 'react-native';
+import type {ViewProps} from 'ViewPropTypes';
+import type {HostComponent} from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 export interface NativeProps extends ViewProps {
@@ -111,7 +111,7 @@ export interface NativeProps extends ViewProps {
 }
 
 export default codegenNativeComponent<NativeProps>(
-  '<FABRIC COMPONENT>'
+  '<FABRIC COMPONENT>',
 ) as HostComponent<NativeProps>;
 ```
 
@@ -121,8 +121,6 @@ export default codegenNativeComponent<NativeProps>(
 ### Supported Types
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
-
-<!-- alex ignore primitive -->
 
 In general, this means you can use primitive types (strings, numbers, booleans), as well as function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you will need to ens
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, you will also need to find a way to resolve this type ambiguity as type unions are intentionally not supported.
 
 ## Make sure _autolinking_ is enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available at https://github.com/react-native-community/cli/blob/master/docs/autolinking.md.
 
@@ -501,10 +497,10 @@ return <RNTMyNativeViewNativeComponent />;
 ```
 
 ```js title="RNTMyNativeViewNativeComponent.js"
-import { requireNativeComponent } from 'react-native';
+import {requireNativeComponent} from 'react-native';
 
 const RNTMyNativeViewNativeComponent = requireNativeComponent(
-  'RNTMyNativeView'
+  'RNTMyNativeView',
 );
 
 export default RNTMyNativeViewNativeComponent;

--- a/cnwebsite/versioned_docs/version-0.70/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.70/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.71/colors.md
+++ b/cnwebsite/versioned_docs/version-0.71/colors.md
@@ -53,8 +53,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 
 你还可以使用颜色名称来作为颜色值. React Native 遵循[CSS3 规范](http://www.w3.org/TR/css3-color/#svg-color)：
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.71/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.71/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.71/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.71/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.72/colors.md
+++ b/cnwebsite/versioned_docs/version-0.72/colors.md
@@ -53,8 +53,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 
 你还可以使用颜色名称来作为颜色值. React Native 遵循[CSS3 规范](http://www.w3.org/TR/css3-color/#svg-color)：
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.72/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.72/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.72/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.72/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.73/colors.md
+++ b/cnwebsite/versioned_docs/version-0.73/colors.md
@@ -57,8 +57,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 React Native 仅支持小写颜色名称。不支持大写颜色名称。
 :::
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.73/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.73/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.73/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.73/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.74/colors.md
+++ b/cnwebsite/versioned_docs/version-0.74/colors.md
@@ -57,8 +57,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 React Native 仅支持小写颜色名称。不支持大写颜色名称。
 :::
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.74/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.74/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.74/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.74/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.75/colors.md
+++ b/cnwebsite/versioned_docs/version-0.75/colors.md
@@ -57,8 +57,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 React Native 仅支持小写颜色名称。不支持大写颜色名称。
 :::
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.75/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.75/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.75/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.75/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.76/colors.md
+++ b/cnwebsite/versioned_docs/version-0.76/colors.md
@@ -57,8 +57,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 React Native 仅支持小写颜色名称。不支持大写颜色名称。
 :::
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.76/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.76/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.76/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.76/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.76/the-new-architecture/create-module-library.md
+++ b/cnwebsite/versioned_docs/version-0.76/the-new-architecture/create-module-library.md
@@ -70,8 +70,6 @@ npx create-react-native-library@latest <Name of Your Library>
 
 本指南的其余部分假设你有一个本地 Turbo Native 模块在你的应用中，遵循网站上其他指南中的指南：平台特定的 Turbo Native 模块，或 [跨平台的 Turbo Native 模块](./pure-cxx-modules)。但它也适用于组件和旧架构的模块和组件。你需要复制和更新你需要的文件。
 
-<!-- TODO: add links for Turbo Native Modules -->
-
 1. **[旧架构不需要这一步]** 将你在应用的 `specs` 文件夹中的代码移动到 `create-react-native-library` 创建的 `src` 文件夹中。
 2. 更新 `index.ts` 文件以正确导出 Turbo Native 模块规范，以便可以从库中访问它。例如：
 
@@ -82,7 +80,6 @@ export default NativeSampleModule;
 ```
 
 3. 复制原生模块：
-
    - 用你在应用中为原生模块编写的代码替换 `android/src/main/java/com/<name-of-the-module>` 中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `ios` 文件夹中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `cpp` 文件夹中的代码，如果有的话。

--- a/cnwebsite/versioned_docs/version-0.76/the-new-architecture/using-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.76/the-new-architecture/using-codegen.md
@@ -21,8 +21,6 @@ npx @react-native-community/cli@latest init SampleApp --version 0.76.0
 
 **Codegen** 用于生成自定义模块或组件的粘合代码。有关如何创建它们的更多详细信息，请参阅 Turbo Native 模块和 Fabric Native 组件的指南。
 
-<!-- TODO: add links -->
-
 ## 配置 Codegen
 
 你可以通过修改 `package.json` 文件来配置 Codegen。Codegen 由一个名为 `codegenConfig` 的自定义字段控制。

--- a/cnwebsite/versioned_docs/version-0.76/the-new-architecture/what-is-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.76/the-new-architecture/what-is-codegen.md
@@ -4,8 +4,6 @@
 
 React Native 会在每次构建 iOS 或 Android 应用时自动调用 **Codegen**。偶尔，您可能需要手动运行 **Codegen** 脚本来了解实际生成的类型和文件：这在开发 Turbo Native Modules 和 Fabric Native Components 时很常见。
 
-<!-- TODO: Add links to TM and FC -->
-
 ## Codegen 是如何工作的
 
 **Codegen** 是一个与 React Native 应用紧密耦合的工具。**Codegen** 脚本位于 `react-native` NPM 包中，并在构建时调用这些脚本。

--- a/cnwebsite/versioned_docs/version-0.77/colors.md
+++ b/cnwebsite/versioned_docs/version-0.77/colors.md
@@ -57,8 +57,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 React Native 仅支持小写颜色名称。不支持大写颜色名称。
 :::
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.77/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.77/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.77/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.77/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.77/the-new-architecture/create-module-library.md
+++ b/cnwebsite/versioned_docs/version-0.77/the-new-architecture/create-module-library.md
@@ -70,8 +70,6 @@ npx create-react-native-library@latest <Name of Your Library>
 
 本指南的其余部分假设你有一个本地 Turbo Native 模块在你的应用中，遵循网站上其他指南中的指南：平台特定的 Turbo Native 模块，或 [跨平台的 Turbo Native 模块](./pure-cxx-modules)。但它也适用于组件和旧架构的模块和组件。你需要复制和更新你需要的文件。
 
-<!-- TODO: add links for Turbo Native Modules -->
-
 1. **[旧架构不需要这一步]** 将你在应用的 `specs` 文件夹中的代码移动到 `create-react-native-library` 创建的 `src` 文件夹中。
 2. 更新 `index.ts` 文件以正确导出 Turbo Native 模块规范，以便可以从库中访问它。例如：
 
@@ -82,7 +80,6 @@ export default NativeSampleModule;
 ```
 
 3. 复制原生模块：
-
    - 用你在应用中为原生模块编写的代码替换 `android/src/main/java/com/<name-of-the-module>` 中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `ios` 文件夹中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `cpp` 文件夹中的代码，如果有的话。

--- a/cnwebsite/versioned_docs/version-0.77/the-new-architecture/using-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.77/the-new-architecture/using-codegen.md
@@ -21,8 +21,6 @@ npx @react-native-community/cli@latest init SampleApp --version 0.76.0
 
 **Codegen** 用于生成自定义模块或组件的粘合代码。有关如何创建它们的更多详细信息，请参阅 Turbo Native 模块和 Fabric Native 组件的指南。
 
-<!-- TODO: add links -->
-
 ## 配置 Codegen
 
 你可以通过修改 `package.json` 文件来配置 Codegen。Codegen 由一个名为 `codegenConfig` 的自定义字段控制。

--- a/cnwebsite/versioned_docs/version-0.77/the-new-architecture/what-is-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.77/the-new-architecture/what-is-codegen.md
@@ -4,8 +4,6 @@
 
 React Native 会在每次构建 iOS 或 Android 应用时自动调用 **Codegen**。偶尔，您可能需要手动运行 **Codegen** 脚本来了解实际生成的类型和文件：这在开发 Turbo Native Modules 和 Fabric Native Components 时很常见。
 
-<!-- TODO: Add links to TM and FC -->
-
 ## Codegen 是如何工作的
 
 **Codegen** 是一个与 React Native 应用紧密耦合的工具。**Codegen** 脚本位于 `react-native` NPM 包中，并在构建时调用这些脚本。

--- a/cnwebsite/versioned_docs/version-0.78/colors.md
+++ b/cnwebsite/versioned_docs/version-0.78/colors.md
@@ -57,8 +57,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 React Native 仅支持小写颜色名称。不支持大写颜色名称。
 :::
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.78/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.78/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.78/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.78/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.78/the-new-architecture/create-module-library.md
+++ b/cnwebsite/versioned_docs/version-0.78/the-new-architecture/create-module-library.md
@@ -70,8 +70,6 @@ npx create-react-native-library@latest <Name of Your Library>
 
 本指南的其余部分假设你有一个本地 Turbo Native 模块在你的应用中，遵循网站上其他指南中的指南：平台特定的 Turbo Native 模块，或 [跨平台的 Turbo Native 模块](./pure-cxx-modules)。但它也适用于组件和旧架构的模块和组件。你需要复制和更新你需要的文件。
 
-<!-- TODO: add links for Turbo Native Modules -->
-
 1. **[旧架构不需要这一步]** 将你在应用的 `specs` 文件夹中的代码移动到 `create-react-native-library` 创建的 `src` 文件夹中。
 2. 更新 `index.ts` 文件以正确导出 Turbo Native 模块规范，以便可以从库中访问它。例如：
 
@@ -82,7 +80,6 @@ export default NativeSampleModule;
 ```
 
 3. 复制原生模块：
-
    - 用你在应用中为原生模块编写的代码替换 `android/src/main/java/com/<name-of-the-module>` 中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `ios` 文件夹中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `cpp` 文件夹中的代码，如果有的话。

--- a/cnwebsite/versioned_docs/version-0.78/the-new-architecture/using-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.78/the-new-architecture/using-codegen.md
@@ -21,8 +21,6 @@ npx @react-native-community/cli@latest init SampleApp --version 0.76.0
 
 **Codegen** 用于生成自定义模块或组件的粘合代码。有关如何创建它们的更多详细信息，请参阅 Turbo Native 模块和 Fabric Native 组件的指南。
 
-<!-- TODO: add links -->
-
 ## 配置 Codegen
 
 你可以通过修改 `package.json` 文件来配置 Codegen。Codegen 由一个名为 `codegenConfig` 的自定义字段控制。

--- a/cnwebsite/versioned_docs/version-0.78/the-new-architecture/what-is-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.78/the-new-architecture/what-is-codegen.md
@@ -4,8 +4,6 @@
 
 React Native 会在每次构建 iOS 或 Android 应用时自动调用 **Codegen**。偶尔，您可能需要手动运行 **Codegen** 脚本来了解实际生成的类型和文件：这在开发 Turbo Native Modules 和 Fabric Native Components 时很常见。
 
-<!-- TODO: Add links to TM and FC -->
-
 ## Codegen 是如何工作的
 
 **Codegen** 是一个与 React Native 应用紧密耦合的工具。**Codegen** 脚本位于 `react-native` NPM 包中，并在构建时调用这些脚本。

--- a/cnwebsite/versioned_docs/version-0.79/colors.md
+++ b/cnwebsite/versioned_docs/version-0.79/colors.md
@@ -57,8 +57,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 React Native 仅支持小写颜色名称。不支持大写颜色名称。
 :::
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.79/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.79/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.79/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.79/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.79/the-new-architecture/create-module-library.md
+++ b/cnwebsite/versioned_docs/version-0.79/the-new-architecture/create-module-library.md
@@ -70,8 +70,6 @@ npx create-react-native-library@latest <Name of Your Library>
 
 本指南的其余部分假设你有一个本地 Turbo Native 模块在你的应用中，遵循网站上其他指南中的指南：平台特定的 Turbo Native 模块，或 [跨平台的 Turbo Native 模块](./pure-cxx-modules)。但它也适用于组件和旧架构的模块和组件。你需要复制和更新你需要的文件。
 
-<!-- TODO: add links for Turbo Native Modules -->
-
 1. **[旧架构不需要这一步]** 将你在应用的 `specs` 文件夹中的代码移动到 `create-react-native-library` 创建的 `src` 文件夹中。
 2. 更新 `index.ts` 文件以正确导出 Turbo Native 模块规范，以便可以从库中访问它。例如：
 
@@ -82,7 +80,6 @@ export default NativeSampleModule;
 ```
 
 3. 复制原生模块：
-
    - 用你在应用中为原生模块编写的代码替换 `android/src/main/java/com/<name-of-the-module>` 中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `ios` 文件夹中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `cpp` 文件夹中的代码，如果有的话。

--- a/cnwebsite/versioned_docs/version-0.79/the-new-architecture/using-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.79/the-new-architecture/using-codegen.md
@@ -21,8 +21,6 @@ npx @react-native-community/cli@latest init SampleApp --version 0.76.0
 
 **Codegen** 用于生成自定义模块或组件的粘合代码。有关如何创建它们的更多详细信息，请参阅 Turbo Native 模块和 Fabric Native 组件的指南。
 
-<!-- TODO: add links -->
-
 ## 配置 Codegen
 
 你可以通过修改 `package.json` 文件来配置 Codegen。Codegen 由一个名为 `codegenConfig` 的自定义字段控制。

--- a/cnwebsite/versioned_docs/version-0.79/the-new-architecture/what-is-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.79/the-new-architecture/what-is-codegen.md
@@ -4,8 +4,6 @@
 
 React Native 会在每次构建 iOS 或 Android 应用时自动调用 **Codegen**。偶尔，您可能需要手动运行 **Codegen** 脚本来了解实际生成的类型和文件：这在开发 Turbo Native Modules 和 Fabric Native Components 时很常见。
 
-<!-- TODO: Add links to TM and FC -->
-
 ## Codegen 是如何工作的
 
 **Codegen** 是一个与 React Native 应用紧密耦合的工具。**Codegen** 脚本位于 `react-native` NPM 包中，并在构建时调用这些脚本。

--- a/cnwebsite/versioned_docs/version-0.80/colors.md
+++ b/cnwebsite/versioned_docs/version-0.80/colors.md
@@ -57,8 +57,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 React Native 仅支持小写颜色名称。不支持大写颜色名称。
 :::
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.80/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.80/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.80/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.80/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.80/the-new-architecture/create-module-library.md
+++ b/cnwebsite/versioned_docs/version-0.80/the-new-architecture/create-module-library.md
@@ -70,8 +70,6 @@ npx create-react-native-library@latest <Name of Your Library>
 
 本指南的其余部分假设你有一个本地 Turbo Native 模块在你的应用中，遵循网站上其他指南中的指南：平台特定的 Turbo Native 模块，或 [跨平台的 Turbo Native 模块](./pure-cxx-modules)。但它也适用于组件和旧架构的模块和组件。你需要复制和更新你需要的文件。
 
-<!-- TODO: add links for Turbo Native Modules -->
-
 1. **[旧架构不需要这一步]** 将你在应用的 `specs` 文件夹中的代码移动到 `create-react-native-library` 创建的 `src` 文件夹中。
 2. 更新 `index.ts` 文件以正确导出 Turbo Native 模块规范，以便可以从库中访问它。例如：
 
@@ -82,7 +80,6 @@ export default NativeSampleModule;
 ```
 
 3. 复制原生模块：
-
    - 用你在应用中为原生模块编写的代码替换 `android/src/main/java/com/<name-of-the-module>` 中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `ios` 文件夹中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `cpp` 文件夹中的代码，如果有的话。

--- a/cnwebsite/versioned_docs/version-0.80/the-new-architecture/using-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.80/the-new-architecture/using-codegen.md
@@ -21,8 +21,6 @@ npx @react-native-community/cli@latest init SampleApp --version 0.76.0
 
 **Codegen** 用于生成自定义模块或组件的粘合代码。有关如何创建它们的更多详细信息，请参阅 Turbo Native 模块和 Fabric Native 组件的指南。
 
-<!-- TODO: add links -->
-
 ## 配置 Codegen
 
 你可以通过修改 `package.json` 文件来配置 Codegen。Codegen 由一个名为 `codegenConfig` 的自定义字段控制。

--- a/cnwebsite/versioned_docs/version-0.80/the-new-architecture/what-is-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.80/the-new-architecture/what-is-codegen.md
@@ -4,8 +4,6 @@
 
 React Native 会在每次构建 iOS 或 Android 应用时自动调用 **Codegen**。偶尔，您可能需要手动运行 **Codegen** 脚本来了解实际生成的类型和文件：这在开发 Turbo Native Modules 和 Fabric Native Components 时很常见。
 
-<!-- TODO: Add links to TM and FC -->
-
 ## Codegen 是如何工作的
 
 **Codegen** 是一个与 React Native 应用紧密耦合的工具。**Codegen** 脚本位于 `react-native` NPM 包中，并在构建时调用这些脚本。

--- a/cnwebsite/versioned_docs/version-0.81/colors.md
+++ b/cnwebsite/versioned_docs/version-0.81/colors.md
@@ -57,8 +57,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 React Native 仅支持小写颜色名称。不支持大写颜色名称。
 :::
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.81/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.81/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.81/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.81/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.81/the-new-architecture/create-module-library.md
+++ b/cnwebsite/versioned_docs/version-0.81/the-new-architecture/create-module-library.md
@@ -70,8 +70,6 @@ npx create-react-native-library@latest <Name of Your Library>
 
 本指南的其余部分假设你有一个本地 Turbo Native 模块在你的应用中，遵循网站上其他指南中的指南：平台特定的 Turbo Native 模块，或 [跨平台的 Turbo Native 模块](./pure-cxx-modules)。但它也适用于组件和旧架构的模块和组件。你需要复制和更新你需要的文件。
 
-<!-- TODO: add links for Turbo Native Modules -->
-
 1. **[旧架构不需要这一步]** 将你在应用的 `specs` 文件夹中的代码移动到 `create-react-native-library` 创建的 `src` 文件夹中。
 2. 更新 `index.ts` 文件以正确导出 Turbo Native 模块规范，以便可以从库中访问它。例如：
 
@@ -82,7 +80,6 @@ export default NativeSampleModule;
 ```
 
 3. 复制原生模块：
-
    - 用你在应用中为原生模块编写的代码替换 `android/src/main/java/com/<name-of-the-module>` 中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `ios` 文件夹中的代码，如果有的话。
    - 用你在应用中为原生模块编写的代码替换 `cpp` 文件夹中的代码，如果有的话。

--- a/cnwebsite/versioned_docs/version-0.81/the-new-architecture/using-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.81/the-new-architecture/using-codegen.md
@@ -21,8 +21,6 @@ npx @react-native-community/cli@latest init SampleApp --version 0.76.0
 
 **Codegen** 用于生成自定义模块或组件的粘合代码。有关如何创建它们的更多详细信息，请参阅 Turbo Native 模块和 Fabric Native 组件的指南。
 
-<!-- TODO: add links -->
-
 ## 配置 Codegen
 
 你可以通过修改 `package.json` 文件来配置 Codegen。Codegen 由一个名为 `codegenConfig` 的自定义字段控制。

--- a/cnwebsite/versioned_docs/version-0.81/the-new-architecture/what-is-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.81/the-new-architecture/what-is-codegen.md
@@ -4,8 +4,6 @@
 
 React Native 会在每次构建 iOS 或 Android 应用时自动调用 **Codegen**。偶尔，您可能需要手动运行 **Codegen** 脚本来了解实际生成的类型和文件：这在开发 Turbo Native Modules 和 Fabric Native Components 时很常见。
 
-<!-- TODO: Add links to TM and FC -->
-
 ## Codegen 是如何工作的
 
 **Codegen** 是一个与 React Native 应用紧密耦合的工具。**Codegen** 脚本位于 `react-native` NPM 包中，并在构建时调用这些脚本。

--- a/cnwebsite/versioned_docs/version-0.82/colors.md
+++ b/cnwebsite/versioned_docs/version-0.82/colors.md
@@ -57,8 +57,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 React Native 仅支持小写颜色名称。不支持大写颜色名称。
 :::
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.82/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.82/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.82/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.82/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.82/the-new-architecture/create-module-library.md
+++ b/cnwebsite/versioned_docs/version-0.82/the-new-architecture/create-module-library.md
@@ -70,8 +70,6 @@ npx create-react-native-library@latest <Name of Your Library>
 
 本指南的其余部分假设您的应用中有一个本地 Turbo Native Module，按照网站中其他指南所示的指南创建：平台特定的 Turbo Native Modules，或[跨平台 Turbo Native Modules](./pure-cxx-modules)。但它也适用于组件和旧架构模块和组件。您需要调整需要复制和更新的文件。
 
-<!-- TODO: add links for Turbo Native Modules -->
-
 1. **[旧架构模块和组件不需要]** 将应用中 `specs` 文件夹中的代码移动到 `create-react-native-library` 文件夹创建的 `src` 文件夹中。
 2. 更新 `index.ts` 文件以正确导出 Turbo Native Module 规范，使其可从库访问。例如：
 

--- a/cnwebsite/versioned_docs/version-0.82/the-new-architecture/using-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.82/the-new-architecture/using-codegen.md
@@ -24,8 +24,6 @@ import {getCurrentVersion} from '@site/src/getCurrentVersion';
 
 **Codegen** 用于为您的自定义模块或组件生成粘合代码。有关如何创建它们的更多详细信息，请参阅 Turbo Native Modules 和 Fabric Native Components 的指南。
 
-<!-- TODO: add links -->
-
 ## 配置 **Codegen**
 
 可以通过修改 `package.json` 文件来配置应用中的 **Codegen**。**Codegen** 由一个名为 `codegenConfig` 的自定义字段控制。

--- a/cnwebsite/versioned_docs/version-0.82/the-new-architecture/what-is-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.82/the-new-architecture/what-is-codegen.md
@@ -4,8 +4,6 @@
 
 每次构建 iOS 或 Android 应用时，React Native 都会自动调用 Codegen。有时，您可能希望手动运行 Codegen 脚本以了解实际生成了哪些类型和文件：这是开发 [Turbo Native Modules](/docs/turbo-native-modules-introduction) 和 Fabric Native Components 时的常见场景。
 
-<!-- TODO: Add links to TM and FC -->
-
 ## Codegen 的工作原理
 
 **Codegen** 是一个与 React Native 应用紧密耦合的过程。Codegen 脚本位于 `react-native` NPM 包中，应用在构建时调用这些脚本。

--- a/cnwebsite/versioned_docs/version-0.83/colors.md
+++ b/cnwebsite/versioned_docs/version-0.83/colors.md
@@ -57,8 +57,6 @@ React Native 还支持将颜色表示为`int`值（以 RGB 颜色模式）：
 React Native 仅支持小写颜色名称。不支持大写颜色名称。
 :::
 
-<!-- alex ignore black white -->
-
 - <ins style={{background: '#f0f8ff'}} className="color-box" /> aliceblue (<code>#f0f8ff</code>)
 - <ins style={{background: '#faebd7'}} className="color-box" /> antiquewhite (<code>#faebd7</code>)
 - <ins style={{background: '#00ffff'}} className="color-box" /> aqua (<code>#00ffff</code>)

--- a/cnwebsite/versioned_docs/version-0.83/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.83/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.83/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.83/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.83/the-new-architecture/create-module-library.md
+++ b/cnwebsite/versioned_docs/version-0.83/the-new-architecture/create-module-library.md
@@ -70,8 +70,6 @@ npx create-react-native-library@latest <Name of Your Library>
 
 本指南的其余部分假设您的应用中有一个本地 Turbo Native Module，按照网站中其他指南所示的指南创建：平台特定的 Turbo Native Modules，或[跨平台 Turbo Native Modules](./pure-cxx-modules)。但它也适用于组件和旧架构模块和组件。您需要调整需要复制和更新的文件。
 
-<!-- TODO: add links for Turbo Native Modules -->
-
 1. **[旧架构模块和组件不需要]** 将应用中 `specs` 文件夹中的代码移动到 `create-react-native-library` 文件夹创建的 `src` 文件夹中。
 2. 更新 `index.ts` 文件以正确导出 Turbo Native Module 规范，使其可从库访问。例如：
 

--- a/cnwebsite/versioned_docs/version-0.83/the-new-architecture/using-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.83/the-new-architecture/using-codegen.md
@@ -24,8 +24,6 @@ import {getCurrentVersion} from '@site/src/getCurrentVersion';
 
 **Codegen** 用于为您的自定义模块或组件生成粘合代码。有关如何创建它们的更多详细信息，请参阅 Turbo Native Modules 和 Fabric Native Components 的指南。
 
-<!-- TODO: add links -->
-
 ## 配置 **Codegen**
 
 可以通过修改 `package.json` 文件来配置应用中的 **Codegen**。**Codegen** 由一个名为 `codegenConfig` 的自定义字段控制。

--- a/cnwebsite/versioned_docs/version-0.83/the-new-architecture/what-is-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.83/the-new-architecture/what-is-codegen.md
@@ -4,8 +4,6 @@
 
 每次构建 iOS 或 Android 应用时，React Native 都会自动调用 Codegen。有时，您可能希望手动运行 Codegen 脚本以了解实际生成了哪些类型和文件：这是开发 [Turbo Native Modules](/docs/turbo-native-modules-introduction) 和 Fabric Native Components 时的常见场景。
 
-<!-- TODO: Add links to TM and FC -->
-
 ## Codegen 的工作原理
 
 **Codegen** 是一个与 React Native 应用紧密耦合的过程。Codegen 脚本位于 `react-native` NPM 包中，应用在构建时调用这些脚本。

--- a/cnwebsite/versioned_docs/version-0.84/new-architecture-library-intro.md
+++ b/cnwebsite/versioned_docs/version-0.84/new-architecture-library-intro.md
@@ -122,8 +122,6 @@ export default codegenNativeComponent<NativeProps>(
 
 When using Flow or TypeScript, you will be using [type annotations](https://flow.org/en/docs/types/) to define your spec. Keeping in mind that the goal of defining a JavaScript spec is to ensure the generated native interface code is type-safe, the set of supported types will be those that can be mapped one-to-one to a corresponding type on the native platform.
 
-<!-- alex ignore primitive -->
-
 In general, this means you can use primitive types (strings, numbers, booleans), function types, object types, and array types. Union types, on the other hand, are not supported. All types must be read-only. For Flow: either `+` or `$ReadOnly<>` or `{||}` objects. For TypeScript: `readonly` for properties, `Readonly<>` for objects, and `ReadonlyArray<>` for arrays.
 
 > See Appendix [II. Flow Type to Native Type Mapping](new-architecture-appendix#ii-flow-type-to-native-type-mapping).
@@ -149,8 +147,6 @@ Before adopting the New Architecture in your native module, you should ensure yo
 If your existing native module has methods with the same name on multiple platforms, but with different numbers or types of arguments across platforms, you will need to find a way to make these consistent. If you have methods that can take two or more different types for the same argument, then you need to find a way to resolve this type of ambiguity as type unions are intentionally not supported.
 
 ## Make Sure _autolinking_ is Enabled
-
-<!-- alex ignore master -->
 
 [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) is a feature of the React Native CLI that simplifies the installation of third-party React Native libraries. Instructions to enable _autolinking_ are available in the [React Native CLI docs](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
 

--- a/cnwebsite/versioned_docs/version-0.84/running-on-device.md
+++ b/cnwebsite/versioned_docs/version-0.84/running-on-device.md
@@ -80,8 +80,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -157,8 +155,6 @@ $ npx react-native run-android
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
 
-<!-- alex ignore host -->
-
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。
 3.  你应该会看到一个“红屏”错误提示。这是正常的，下面的步骤会解决这个报错。
@@ -233,8 +229,6 @@ $ npx react-native run-android
 你还可以通过 Wi-Fi 连接到开发服务器。你首先需要使用 USB 在你的设备上安装该应用程序，完成之后便可以按照这些说明进行无线调试。在继续之前，你需要知道开发机器的当前 IP 地址。
 
 你可以在**System Preferences** → **Network**中找到 IP 地址。
-
-<!-- alex ignore host -->
 
 1.  首先确保你的电脑和手机设备在**同一个 Wi-Fi 环境**下。
 2.  在设备上运行你的 React Native 应用。和打开其它 App 一样操作。

--- a/cnwebsite/versioned_docs/version-0.84/the-new-architecture/create-module-library.md
+++ b/cnwebsite/versioned_docs/version-0.84/the-new-architecture/create-module-library.md
@@ -70,8 +70,6 @@ npx create-react-native-library@latest <Name of Your Library>
 
 本指南的其余部分假设您的应用中有一个本地 Turbo Native Module，按照网站中其他指南所示的指南创建：平台特定的 Turbo Native Modules，或[跨平台 Turbo Native Modules](./pure-cxx-modules)。但它也适用于组件和旧架构模块和组件。您需要调整需要复制和更新的文件。
 
-<!-- TODO: add links for Turbo Native Modules -->
-
 1. **[旧架构模块和组件不需要]** 将应用中 `specs` 文件夹中的代码移动到 `create-react-native-library` 文件夹创建的 `src` 文件夹中。
 2. 更新 `index.ts` 文件以正确导出 Turbo Native Module 规范，使其可从库访问。例如：
 

--- a/cnwebsite/versioned_docs/version-0.84/the-new-architecture/using-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.84/the-new-architecture/using-codegen.md
@@ -24,8 +24,6 @@ import {getCurrentVersion} from '@site/src/getCurrentVersion';
 
 **Codegen** 用于为您的自定义模块或组件生成粘合代码。有关如何创建它们的更多详细信息，请参阅 Turbo Native Modules 和 Fabric Native Components 的指南。
 
-<!-- TODO: add links -->
-
 ## 配置 **Codegen**
 
 可以通过修改 `package.json` 文件来配置应用中的 **Codegen**。**Codegen** 由一个名为 `codegenConfig` 的自定义字段控制。

--- a/cnwebsite/versioned_docs/version-0.84/the-new-architecture/what-is-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.84/the-new-architecture/what-is-codegen.md
@@ -4,8 +4,6 @@
 
 每次构建 iOS 或 Android 应用时，React Native 都会自动调用 Codegen。有时，您可能希望手动运行 Codegen 脚本以了解实际生成了哪些类型和文件：这是开发 [Turbo Native Modules](/docs/turbo-native-modules-introduction) 和 Fabric Native Components 时的常见场景。
 
-<!-- TODO: Add links to TM and FC -->
-
 ## Codegen 的工作原理
 
 **Codegen** 是一个与 React Native 应用紧密耦合的过程。Codegen 脚本位于 `react-native` NPM 包中，应用在构建时调用这些脚本。

--- a/cnwebsite/versioned_docs/version-0.85/the-new-architecture/create-module-library.md
+++ b/cnwebsite/versioned_docs/version-0.85/the-new-architecture/create-module-library.md
@@ -70,8 +70,6 @@ npx create-react-native-library@latest <Name of Your Library>
 
 本指南的其余部分假设您的应用中有一个本地 Turbo Native Module，按照网站中其他指南所示的指南创建：平台特定的 Turbo Native Modules，或[跨平台 Turbo Native Modules](./pure-cxx-modules)。但它也适用于组件和旧架构模块和组件。您需要调整需要复制和更新的文件。
 
-<!-- TODO: add links for Turbo Native Modules -->
-
 1. **[旧架构模块和组件不需要]** 将应用中 `specs` 文件夹中的代码移动到 `create-react-native-library` 文件夹创建的 `src` 文件夹中。
 2. 更新 `index.ts` 文件以正确导出 Turbo Native Module 规范，使其可从库访问。例如：
 

--- a/cnwebsite/versioned_docs/version-0.85/the-new-architecture/using-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.85/the-new-architecture/using-codegen.md
@@ -24,8 +24,6 @@ import {getCurrentVersion} from '@site/src/getCurrentVersion';
 
 **Codegen** 用于为您的自定义模块或组件生成粘合代码。有关如何创建它们的更多详细信息，请参阅 Turbo Native Modules 和 Fabric Native Components 的指南。
 
-<!-- TODO: add links -->
-
 ## 配置 **Codegen**
 
 可以通过修改 `package.json` 文件来配置应用中的 **Codegen**。**Codegen** 由一个名为 `codegenConfig` 的自定义字段控制。

--- a/cnwebsite/versioned_docs/version-0.85/the-new-architecture/what-is-codegen.md
+++ b/cnwebsite/versioned_docs/version-0.85/the-new-architecture/what-is-codegen.md
@@ -4,8 +4,6 @@
 
 每次构建 iOS 或 Android 应用时，React Native 都会自动调用 Codegen。有时，您可能希望手动运行 Codegen 脚本以了解实际生成了哪些类型和文件：这是开发 [Turbo Native Modules](/docs/turbo-native-modules-introduction) 和 Fabric Native Components 时的常见场景。
 
-<!-- TODO: Add links to TM and FC -->
-
 ## Codegen 的工作原理
 
 **Codegen** 是一个与 React Native 应用紧密耦合的过程。Codegen 脚本位于 `react-native` NPM 包中，应用在构建时调用这些脚本。


### PR DESCRIPTION
## 变更内容

### 编译修复
- **markdown.format: detect**: Docusaurus 3.10 默认用 MDX 解析器处理所有 .md 文件，导致 HTML 注释和自定义 heading ID 等语法报错。设置 detect 后 .md 按标准 markdown 解析，.mdx 按 MDX 解析
- **删除 versioned_docs 中的 HTML 注释**: alex ignore、TODO 等注释在 MDX v3 中不合法，已批量清除
- **删除自定义 heading ID**: cndocs/legacy/native-components-android.md 中的自定义 ID 在 MDX 中被当作无效 JSX 表达式
- **清理侧边栏**: 移除对已删除文档的引用（metro、what-is-codegen、using-codegen、create-module-library）

### getting-started 调整
- **Tab 顺序**: 将 React Native CLI Quickstart 移到 Expo Go Quickstart 之前（符合 CN 文档不 promote Expo 的原则）
- **默认 Tab**: defaultGuide 从 quickstart(Expo) 改为 native(CLI)

## 验证
- [x] yarn --cwd cnwebsite build 编译成功
- [x] 79 个文件变更，主要是 versioned_docs 的 HTML 注释清理


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized Getting Started guide with improved tab-based navigation for platform and OS selection
  * Updated default guide selection to emphasize native development workflow
  * Cleaned up documentation formatting across guide versions

* **Configuration**
  * Reordered development guide options and adjusted default preferences for better discovery

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reactnativecn/react-native-website/pull/1022)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->