### PR TITLE
fix(ci): install cnwebsite deps before build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "cnwebsite/**"
       - "cndocs/**"
+      - ".github/workflows/gh-pages.yml"
 
 jobs:
   deploy:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=22"
   },
   "workspaces": [
-    "website",
+    "cnwebsite",
     "packages/*",
     "plugins/*"
   ],


### PR DESCRIPTION
cnwebsite 不在 root yarn workspaces 里，根目录 yarn install 不会安装 cnwebsite 的依赖（包括 @docusaurus/core），导致 CI 构建报 docusaurus: not found (exit 127)。

修复：
1. Install 步骤增加 cd cnwebsite && yarn install
2. paths 过滤器增加 .github/workflows/gh-pages.yml，确保 workflow 变更也能触发构建

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Pages deployment workflow configuration to improve build process consistency and self-triggering capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reactnativecn/react-native-website/pull/1023)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->