### PR TITLE
fix(cnwebsite): remove markdown.format 'detect' to fix JSX rendering in .md files

### DIFF
--- a/cnwebsite/docusaurus.config.ts
+++ b/cnwebsite/docusaurus.config.ts
@@ -33,7 +33,6 @@ const isDeployPreview =
 const config: Config = {
   markdown: {
     mermaid: true,
-    format: 'detect',
   },
   themes: ['@docusaurus/theme-mermaid'],
   future: {

--- a/cnwebsite/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-fabric-components.md
@@ -29,7 +29,7 @@ While the last step is the same for all the platforms, the first two steps are d
 
 ## Configure the Fabric Component Dependencies
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 The Apple platform installs Fabric Components using [Cocoapods](https://cocoapods.org) as dependency manager.
 

--- a/cnwebsite/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.70/the-new-architecture/backward-compatibility-turbomodules.md
@@ -29,7 +29,7 @@ While the last step is the same for all the platforms, the first two steps are d
 
 ## Configure the TurboModule Dependencies
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 The Apple platform installs TurboModules using [Cocoapods](https://cocoapods.org) as dependency manager.
 

--- a/cnwebsite/versioned_docs/version-0.71/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.71/the-new-architecture/backward-compatibility-fabric-components.md
@@ -29,7 +29,7 @@ While the last step is the same for all the platforms, the first two steps are d
 
 ## Configure the Fabric Component Dependencies
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 The Apple platform installs Fabric Components using [Cocoapods](https://cocoapods.org) as dependency manager.
 

--- a/cnwebsite/versioned_docs/version-0.71/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.71/the-new-architecture/backward-compatibility-turbomodules.md
@@ -29,7 +29,7 @@ While the last step is the same for all the platforms, the first two steps are d
 
 ## Configure the TurboModule Dependencies
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 The Apple platform installs TurboModules using [Cocoapods](https://cocoapods.org) as dependency manager.
 

--- a/cnwebsite/versioned_docs/version-0.72/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.72/the-new-architecture/backward-compatibility-fabric-components.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Fabric 原生组件依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用 [Cocoapods](https://cocoapods.org) 作为依赖管理器来安装 Fabric 原生组件。
 
@@ -498,23 +498,3 @@ import MyComponent from 'your-component/src/index';
 ```
 
 由于 `codegenNativeComponent` 在底层调用了 `requireNativeComponent`，我们需要重新导出组件，以避免多次注册。
-
-<Tabs groupId="fabric-component-backward-compatibility" queryString
-      defaultValue={constants.defaultFabricComponentSpecLanguage}
-      values={constants.fabricComponentSpecLanguages}>
-<TabItem value="Flow">
-
-```ts
-// @flow
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-<TabItem value="TypeScript">
-
-```ts
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-</Tabs>

--- a/cnwebsite/versioned_docs/version-0.72/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.72/the-new-architecture/backward-compatibility-turbomodules.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Turbo 原生模块依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用[Cocoapods](https://cocoapods.org)作为依赖管理器来安装 Turbo 原生模块。
 

--- a/cnwebsite/versioned_docs/version-0.73/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.73/the-new-architecture/backward-compatibility-fabric-components.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Fabric 原生组件依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用 [Cocoapods](https://cocoapods.org) 作为依赖管理器来安装 Fabric 原生组件。
 
@@ -498,23 +498,3 @@ import MyComponent from 'your-component/src/index';
 ```
 
 由于 `codegenNativeComponent` 在底层调用了 `requireNativeComponent`，我们需要重新导出组件，以避免多次注册。
-
-<Tabs groupId="fabric-component-backward-compatibility" queryString
-      defaultValue={constants.defaultFabricComponentSpecLanguage}
-      values={constants.fabricComponentSpecLanguages}>
-<TabItem value="Flow">
-
-```ts
-// @flow
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-<TabItem value="TypeScript">
-
-```ts
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-</Tabs>

--- a/cnwebsite/versioned_docs/version-0.73/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.73/the-new-architecture/backward-compatibility-turbomodules.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Turbo 原生模块依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用[Cocoapods](https://cocoapods.org)作为依赖管理器来安装 Turbo 原生模块。
 

--- a/cnwebsite/versioned_docs/version-0.74/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.74/the-new-architecture/backward-compatibility-fabric-components.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Fabric 原生组件依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用 [Cocoapods](https://cocoapods.org) 作为依赖管理器来安装 Fabric 原生组件。
 
@@ -498,23 +498,3 @@ import MyComponent from 'your-component/src/index';
 ```
 
 由于 `codegenNativeComponent` 在底层调用了 `requireNativeComponent`，我们需要重新导出组件，以避免多次注册。
-
-<Tabs groupId="fabric-component-backward-compatibility" queryString
-      defaultValue={constants.defaultFabricComponentSpecLanguage}
-      values={constants.fabricComponentSpecLanguages}>
-<TabItem value="Flow">
-
-```ts
-// @flow
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-<TabItem value="TypeScript">
-
-```ts
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-</Tabs>

--- a/cnwebsite/versioned_docs/version-0.74/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.74/the-new-architecture/backward-compatibility-turbomodules.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Turbo 原生模块依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用[Cocoapods](https://cocoapods.org)作为依赖管理器来安装 Turbo 原生模块。
 

--- a/cnwebsite/versioned_docs/version-0.75/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.75/the-new-architecture/backward-compatibility-fabric-components.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Fabric 原生组件依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用 [Cocoapods](https://cocoapods.org) 作为依赖管理器来安装 Fabric 原生组件。
 
@@ -498,23 +498,3 @@ import MyComponent from 'your-component/src/index';
 ```
 
 由于 `codegenNativeComponent` 在底层调用了 `requireNativeComponent`，我们需要重新导出组件，以避免多次注册。
-
-<Tabs groupId="fabric-component-backward-compatibility" queryString
-      defaultValue={constants.defaultFabricComponentSpecLanguage}
-      values={constants.fabricComponentSpecLanguages}>
-<TabItem value="Flow">
-
-```ts
-// @flow
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-<TabItem value="TypeScript">
-
-```ts
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-</Tabs>

--- a/cnwebsite/versioned_docs/version-0.75/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.75/the-new-architecture/backward-compatibility-turbomodules.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Turbo 原生模块依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用[Cocoapods](https://cocoapods.org)作为依赖管理器来安装 Turbo 原生模块。
 

--- a/cnwebsite/versioned_docs/version-0.76/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.76/the-new-architecture/backward-compatibility-fabric-components.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Fabric 原生组件依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用 [Cocoapods](https://cocoapods.org) 作为依赖管理器来安装 Fabric 原生组件。
 
@@ -498,23 +498,3 @@ import MyComponent from 'your-component/src/index';
 ```
 
 由于 `codegenNativeComponent` 在底层调用了 `requireNativeComponent`，我们需要重新导出组件，以避免多次注册。
-
-<Tabs groupId="fabric-component-backward-compatibility" queryString
-      defaultValue={constants.defaultFabricComponentSpecLanguage}
-      values={constants.fabricComponentSpecLanguages}>
-<TabItem value="Flow">
-
-```ts
-// @flow
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-<TabItem value="TypeScript">
-
-```ts
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-</Tabs>

--- a/cnwebsite/versioned_docs/version-0.76/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.76/the-new-architecture/backward-compatibility-turbomodules.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Turbo 原生模块依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用[Cocoapods](https://cocoapods.org)作为依赖管理器来安装 Turbo 原生模块。
 

--- a/cnwebsite/versioned_docs/version-0.77/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.77/the-new-architecture/backward-compatibility-fabric-components.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Fabric 原生组件依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用 [Cocoapods](https://cocoapods.org) 作为依赖管理器来安装 Fabric 原生组件。
 
@@ -498,23 +498,3 @@ import MyComponent from 'your-component/src/index';
 ```
 
 由于 `codegenNativeComponent` 在底层调用了 `requireNativeComponent`，我们需要重新导出组件，以避免多次注册。
-
-<Tabs groupId="fabric-component-backward-compatibility" queryString
-      defaultValue={constants.defaultFabricComponentSpecLanguage}
-      values={constants.fabricComponentSpecLanguages}>
-<TabItem value="Flow">
-
-```ts
-// @flow
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-<TabItem value="TypeScript">
-
-```ts
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-</Tabs>

--- a/cnwebsite/versioned_docs/version-0.77/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.77/the-new-architecture/backward-compatibility-turbomodules.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Turbo 原生模块依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用[Cocoapods](https://cocoapods.org)作为依赖管理器来安装 Turbo 原生模块。
 

--- a/cnwebsite/versioned_docs/version-0.78/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.78/the-new-architecture/backward-compatibility-fabric-components.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Fabric 原生组件依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用 [Cocoapods](https://cocoapods.org) 作为依赖管理器来安装 Fabric 原生组件。
 
@@ -498,23 +498,3 @@ import MyComponent from 'your-component/src/index';
 ```
 
 由于 `codegenNativeComponent` 在底层调用了 `requireNativeComponent`，我们需要重新导出组件，以避免多次注册。
-
-<Tabs groupId="fabric-component-backward-compatibility" queryString
-      defaultValue={constants.defaultFabricComponentSpecLanguage}
-      values={constants.fabricComponentSpecLanguages}>
-<TabItem value="Flow">
-
-```ts
-// @flow
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-<TabItem value="TypeScript">
-
-```ts
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-</Tabs>

--- a/cnwebsite/versioned_docs/version-0.78/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.78/the-new-architecture/backward-compatibility-turbomodules.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Turbo 原生模块依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用[Cocoapods](https://cocoapods.org)作为依赖管理器来安装 Turbo 原生模块。
 

--- a/cnwebsite/versioned_docs/version-0.79/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.79/the-new-architecture/backward-compatibility-fabric-components.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Fabric 原生组件依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用 [Cocoapods](https://cocoapods.org) 作为依赖管理器来安装 Fabric 原生组件。
 
@@ -498,23 +498,3 @@ import MyComponent from 'your-component/src/index';
 ```
 
 由于 `codegenNativeComponent` 在底层调用了 `requireNativeComponent`，我们需要重新导出组件，以避免多次注册。
-
-<Tabs groupId="fabric-component-backward-compatibility" queryString
-      defaultValue={constants.defaultFabricComponentSpecLanguage}
-      values={constants.fabricComponentSpecLanguages}>
-<TabItem value="Flow">
-
-```ts
-// @flow
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-<TabItem value="TypeScript">
-
-```ts
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-</Tabs>

--- a/cnwebsite/versioned_docs/version-0.79/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.79/the-new-architecture/backward-compatibility-turbomodules.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Turbo 原生模块依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用[Cocoapods](https://cocoapods.org)作为依赖管理器来安装 Turbo 原生模块。
 

--- a/cnwebsite/versioned_docs/version-0.80/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.80/the-new-architecture/backward-compatibility-fabric-components.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Fabric 原生组件依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用 [Cocoapods](https://cocoapods.org) 作为依赖管理器来安装 Fabric 原生组件。
 
@@ -498,23 +498,3 @@ import MyComponent from 'your-component/src/index';
 ```
 
 由于 `codegenNativeComponent` 在底层调用了 `requireNativeComponent`，我们需要重新导出组件，以避免多次注册。
-
-<Tabs groupId="fabric-component-backward-compatibility" queryString
-      defaultValue={constants.defaultFabricComponentSpecLanguage}
-      values={constants.fabricComponentSpecLanguages}>
-<TabItem value="Flow">
-
-```ts
-// @flow
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-<TabItem value="TypeScript">
-
-```ts
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-</Tabs>

--- a/cnwebsite/versioned_docs/version-0.80/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.80/the-new-architecture/backward-compatibility-turbomodules.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Turbo 原生模块依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用[Cocoapods](https://cocoapods.org)作为依赖管理器来安装 Turbo 原生模块。
 

--- a/cnwebsite/versioned_docs/version-0.81/the-new-architecture/backward-compatibility-fabric-components.md
+++ b/cnwebsite/versioned_docs/version-0.81/the-new-architecture/backward-compatibility-fabric-components.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Fabric 原生组件依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用 [Cocoapods](https://cocoapods.org) 作为依赖管理器来安装 Fabric 原生组件。
 
@@ -498,23 +498,3 @@ import MyComponent from 'your-component/src/index';
 ```
 
 由于 `codegenNativeComponent` 在底层调用了 `requireNativeComponent`，我们需要重新导出组件，以避免多次注册。
-
-<Tabs groupId="fabric-component-backward-compatibility" queryString
-      defaultValue={constants.defaultFabricComponentSpecLanguage}
-      values={constants.fabricComponentSpecLanguages}>
-<TabItem value="Flow">
-
-```ts
-// @flow
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-<TabItem value="TypeScript">
-
-```ts
-export default require('./MyComponentNativeComponent').default;
-```
-
-</TabItem>
-</Tabs>

--- a/cnwebsite/versioned_docs/version-0.81/the-new-architecture/backward-compatibility-turbomodules.md
+++ b/cnwebsite/versioned_docs/version-0.81/the-new-architecture/backward-compatibility-turbomodules.md
@@ -38,7 +38,7 @@ import NewArchitectureWarning from '../\_markdown-new-architecture-warning.mdx';
 
 ## 配置 Turbo 原生模块依赖
 
-### iOS {#dependencies-ios}
+### iOS {/_dependencies-ios_/}
 
 Apple 平台使用[Cocoapods](https://cocoapods.org)作为依赖管理器来安装 Turbo 原生模块。
 


### PR DESCRIPTION
## 问题

`markdown.format: 'detect'` 导致所有 `.md` 文件按纯 Markdown 解析，JSX 组件（`<Tabs>`、`<TabItem>` 等）不会被处理。影响 getting-started 及其他 55+ 个使用 Tabs 的页面。

EN 上游没有此配置，默认全部按 MDX 解析。

## 改动

- 移除 `cnwebsite/docusaurus.config.ts` 中的 `format: 'detect'`，与 EN 上游保持一致
- 将 24 个版本文档中的 `{#custom-id}` 语法转换为 MDX v3 兼容的 `{/*custom-id*/}` 语法（`backward-compatibility-*.md`，版本 0.70-0.81）
- 版本文档中的 HTML comments 均在 code fence 内，MDX 解析安全

## 验证

`yarn build` 通过（67s）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal reference anchors across multiple versions of backward-compatibility guides for Fabric Components and TurboModules.
  * Removed language-specific code examples from JavaScript standardization sections in select documentation versions.

* **Chores**
  * Adjusted Docusaurus markdown configuration settings for diagram format handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reactnativecn/react-native-website/pull/1025?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->