### PR TITLE
docs(cndocs): sync translated API docs

### DIFF
--- a/cndocs/appstate.md
+++ b/cndocs/appstate.md
@@ -13,7 +13,7 @@ AppState 通常在处理推送通知的时候用来决定内容和对应的行�
 - `background` - 应用正在后台运行。用户可能面对以下几种情况：
   - 在别的应用中
   - 停留在桌面
-  - [Android] 处在另一个 `Activity` 中（即便是由你的应用拉起的）
+  - [Android] 处在另一个 `Activity` 中，包括临时的系统 Activity，例如自动填充凭据选择器（即便是由你的应用或系统启动的）
 - [iOS] `inactive` - 此状态表示应用正在前后台的切换过程中，或是处在系统的多任务视图、通知中心，又或是处在来电状态中。
 
 要了解更多信息，可以阅读 [Apple 的文档](https://developer.apple.com/documentation/uikit/app_and_scenes/managing_your_app_s_life_cycle)。

--- a/cndocs/element-nodes.md
+++ b/cndocs/element-nodes.md
@@ -115,7 +115,7 @@ export default ViewWithRefs;
   - [`nodeType`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/nodeType)
   - [`nodeValue`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/nodeValue)
   - [`ownerDocument`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/ownerDocument)
-    - ℹ️ 将返回渲染此组件的[文档实例](/docs/next/document-instances)。
+    - ℹ️ 将返回渲染此组件的[文档节点](/docs/next/document-nodes)。
   - [`parentElement`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/parentElement)
   - [`parentNode`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/parentNode)
   - [`previousSibling`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/previousSibling)

--- a/cndocs/legacy/native-modules-ios.md
+++ b/cndocs/legacy/native-modules-ios.md
@@ -551,7 +551,7 @@ RCT_EXPORT_METHOD(doSomethingExpensive:(NSString *)param callback:(RCTResponseSe
 
 ```
 
-:::info 在模块之间共享调度队列
+:::info[在模块之间共享调度队列]
 `methodQueue` 方法会在模块初始化时调用一次，然后由 React Native 保留，因此你自己不需要保留对该队列的引用，除非你希望在模块中使用它。但是，如果你希望在多个模块之间共享同一个队列，那么你需要确保为每个模块保留并返回相同的队列实例。
 :::
 

--- a/cndocs/signed-apk-android.md
+++ b/cndocs/signed-apk-android.md
@@ -65,11 +65,11 @@ MYAPP_UPLOAD_KEY_PASSWORD=*****
 
 上面的这些会作为全局 Gradle 变量，在后面的步骤中可以用来给应用签名。
 
-:::note 关于使用 git 的说明
+:::note[关于使用 git 的说明]
 将上述 Gradle 变量保存在 `~/.gradle/gradle.properties` 而非 `android/gradle.properties` 中，可以防止它们被提交到 git。你可能需要先在用户主目录下创建 `~/.gradle/gradle.properties` 文件。
 :::
 
-:::note 关于安全性的说明
+:::note[关于安全性的说明]
 如果你不想以明文方式保存密码，且你使用的是 macOS 系统，你也可以把密码[保存到钥匙串（Keychain）中](https://pilloxa.gitlab.io/posts/safer-passwords-in-gradle/)。这样一来你就可以省略掉 `~/.gradle/gradle.properties` 中的后两行。
 :::
 
@@ -174,7 +174,7 @@ android {
 
 Proguard 是一个 Java 字节码混淆压缩工具，它可以移除掉 React Native Java（和它的依赖库中）未被使用到的部分，从而有效地减少 APK 的大小。
 
-:::caution 重要
+:::caution[重要]
 启用 Proguard 之后，你必须再次全面地测试你的应用。Proguard 有时候需要为你引入的每个原生库做一些额外的配置。参见`app/proguard-rules.pro`文件。
 :::
 

--- a/cndocs/text-nodes.md
+++ b/cndocs/text-nodes.md
@@ -73,7 +73,7 @@ export default TextWithRefs;
   - [`nodeType`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/nodeType)
   - [`nodeValue`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/nodeValue)
   - [`ownerDocument`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/ownerDocument)
-    - ℹ️ 将返回渲染此组件的[文档实例](/docs/next/document-instances)。
+    - ℹ️ 将返回渲染此组件的[文档节点](/docs/next/document-nodes)。
   - [`parentElement`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/parentElement)
   - [`parentNode`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/parentNode)
   - [`previousSibling`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/previousSibling)

--- a/cndocs/text-style-props.md
+++ b/cndocs/text-style-props.md
@@ -859,6 +859,8 @@ iOS 上支持通用字体族 `system-ui`、`ui-sans-serif`、`ui-serif`、`ui-mo
 
 ### `textAlignVertical` <div className="label android">Android</div>
 
+`verticalAlign` 样式属性的别名；如果同时使用这两个属性，`verticalAlign` 将优先于 `textAlignVertical`。
+
 | 类型                                            | 默认值   |
 | ----------------------------------------------- | -------- |
 | enum(`'auto'`, `'top'`, `'bottom'`, `'center'`) | `'auto'` |

--- a/cndocs/the-new-architecture/pure-cxx-modules.md
+++ b/cndocs/the-new-architecture/pure-cxx-modules.md
@@ -72,7 +72,7 @@ export default TurboModuleRegistry.getEnforcing<Spec>(
 
 ## 2. Configure Codegen
 
-The next step is to configure [Codegen](what-is-codegen.md) in your `package.json`. Update the file to include:
+The next step is to configure [Codegen](what-is-codegen.mdx) in your `package.json`. Update the file to include:
 
 ```json title="package.json"
      "start": "react-native start",

--- a/cndocs/timers.md
+++ b/cndocs/timers.md
@@ -12,7 +12,7 @@ title: 定时器
 - setImmediate, clearImmediate
 - requestAnimationFrame, cancelAnimationFrame
 
-`requestAnimationFrame(fn)`和`setTimeout(fn, 0)`不同，前者会在每帧刷新之后执行一次，而后者则会尽可能快的执行（在 iPhone5S 上有可能每秒 1000 次以上）。
+`requestAnimationFrame(fn)`和`setTimeout(fn, 0)`不同，前者会在每帧刷新之后执行一次，而后者则会尽可能快地执行（在 iPhone 5S 上有可能每秒 1000 次以上）。
 
 `setImmediate`则会在当前 JavaScript 执行块结束的时候执行，就在将要发送批量响应数据到原生之前。注意如果你在`setImmediate`的回调函数中又执行了`setImmediate`，它会紧接着立刻执行，而不会在调用之前等待原生代码。
 
@@ -20,7 +20,7 @@ title: 定时器
 
 :::note
 在 Android 上调试时，如果调试器和设备之间的时间出现偏差，动画、事件行为等可能无法正常工作，或者结果可能不准确。
-请在调试器机器上运行 ``adb shell \"date `date +%m%d%H%M%Y.%S%3N`\"`` 来纠正此问题。在真实设备上使用需要 root 权限。
+请在调试器机器上运行 ``adb shell "date `date +%m%d%H%M%Y.%S%3N`"`` 来纠正此问题。在真实设备上使用需要 root 权限。
 :::
 
 ## InteractionManager

--- a/cndocs/usecolorscheme.md
+++ b/cndocs/usecolorscheme.md
@@ -7,13 +7,13 @@ title: useColorScheme
 import {useColorScheme} from 'react-native';
 ```
 
-`useColorScheme` 这个React hook 提供并订阅来自Appearance模块的颜色方案更新。返回值表示当前用户首选的颜色方案。该值可以稍后通过直接用户动作（例如，设备设置中的主题选择）或根据时间表（例如，遵循白天/夜晚周期的亮主题和暗主题）来更新。
+`useColorScheme` 这个 React Hook 提供并订阅来自 [`Appearance`](appearance) 模块的颜色方案更新。返回值表示当前生效的颜色方案。该值可以稍后通过直接用户动作（例如，设备设置中的主题选择，或通过 [`setColorScheme`](appearance#setcolorscheme) 在应用级别选择的用户界面样式）或根据时间表（例如，遵循白天/夜晚周期的亮色和暗色主题）来更新。
 
-### 支持的颜色方案
+### 返回值
 
-- `"light"`: 用户倾向于使用浅色主题。
-- `"dark"`: 用户倾向于使用深色主题。
-- `null`: 用户未指定首选颜色方案。
+- `'light'`: 已应用亮色方案。
+- `'dark'`: 已应用暗色方案。
+- `null`: 如果原生 Appearance 模块不可用，则可能返回该值。
 
 ---
 


### PR DESCRIPTION
## Summary

- Synced actual translation drift found by `scripts/sync-translations.sh` after verifying each candidate against upstream docs.
- Updated `cndocs/appstate.md` for the expanded Android background `Activity` explanation.
- Updated `cndocs/element-nodes.md` and `cndocs/text-nodes.md` for the `ownerDocument` terminology/link change from document instance to document node.
- Updated admonition title syntax in `cndocs/legacy/native-modules-ios.md` and `cndocs/signed-apk-android.md`.
- Updated `cndocs/text-style-props.md` with the missing `textAlignVertical` alias note.
- Updated `cndocs/the-new-architecture/pure-cxx-modules.md` for the upstream Codegen link target change.
- Updated `cndocs/timers.md` for the timer wording/command syntax drift.
- Updated `cndocs/usecolorscheme.md` to match the current `Appearance`/`setColorScheme` return-value wording.

## website → cnwebsite sync

- Upstream merge only changed docs/versioned docs typo fixes in this batch.
- Checked `website/package.json` against `cnwebsite/package.json`: no dependency differences.
- Checked upstream merge for `website/package.json`, `website/docusaurus.config.ts`, `website/babel.config.js`, `website/tsconfig.json`, `website/sidebars.ts`, root `package.json`, and `yarn.lock`: no config/dependency files changed, so no `cnwebsite/` config updates were needed.

## Verification

- `git fetch origin && git fetch upstream`
- `git checkout production && git pull --ff-only origin production`
- `git merge upstream/main`
- `git push origin production`
- `bash scripts/sync-translations.sh`
- Candidate-by-candidate docs/cndocs verification; skipped removed stubs and stale false positives.
- `yarn --cwd cnwebsite build` succeeded. The build still emits pre-existing unresolved-link/HTML-minifier warnings in versioned docs, but finishes successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified AppState background state behavior for Android
  * Added information on `textAlignVertical` property as an alias with precedence rules
  * Enhanced `useColorScheme` Hook documentation with clearer behavior descriptions and supported return values
  * Updated documentation links and formatting for consistency across guides

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reactnativecn/react-native-website/pull/1026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->