### PR TITLE
docs(cndocs): sync Pressable ripple docs

### DIFF
--- a/cndocs/pressable.md
+++ b/cndocs/pressable.md
@@ -122,7 +122,7 @@ export default App;
 
 ### `android_ripple` <div className="label android">Android</div>
 
-使用并配置 Android 波纹效果。
+启用 Android 波纹效果并配置其属性。`color` 字段既接受普通颜色，也接受 [`PlatformColor`](platformcolor) 值，因此你可以引用类似 `?attr/colorAccent` 的主题属性。使用 `PlatformColor` 时，波纹会在系统配置变化时（例如在浅色和深色模式之间切换）自动更新。
 
 | Type                                   |
 | -------------------------------------- |
@@ -260,9 +260,9 @@ export default App;
 
 **Properties:**
 
-| Name       | Type            | Required | Description                                                                                                                          |
-| ---------- | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| color      | [color](colors) | No       | 定义波纹的颜色。                                                                                                                      |
-| borderless | boolean         | No       | 定义波纹效果是否包含边框。                                                                                                            |
-| radius     | number          | No       | 定义波纹的半径。                                                                                                                      |
+| Name       | Type            | Required | Description                                                                                                                  |
+| ---------- | --------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| color      | [color](colors) | No       | 定义波纹的颜色。                                                                                                             |
+| borderless | boolean         | No       | 定义波纹效果是否包含边框。                                                                                                   |
+| radius     | number          | No       | 定义波纹的半径。                                                                                                             |
 | foreground | boolean         | No       | 设为 true 可将波纹效果添加到视图的前景而非背景。当子视图有自己的背景色或者你在显示图片时，这很有用，可以避免波纹效果被遮挡。 |


### PR DESCRIPTION
## Summary
- Synced `cndocs/pressable.md` with the upstream `Pressable` documentation update for `android_ripple`.
- Added the missing explanation that `RippleConfig.color` accepts both plain colors and `PlatformColor`, including automatic updates when system configuration changes.
- Ran the sync script and verified the other candidates (`checkbox`, `clipboard`, `colors`, removed-component stubs, `modal`) were already aligned / stale timestamp candidates.

## website → cnwebsite config/deps
- Upstream merge only changed `docs/pressable.md` and `yarn.lock` for this batch.
- `website/package.json` and `cnwebsite/package.json` dependency/devDependency versions are already aligned; no `cnwebsite` config changes were needed.

## Test Plan
- `yarn --cwd cnwebsite build` ✅
  - Build succeeds; it still emits existing non-fatal Docusaurus SSG/HTML-minifier warnings for versioned docs paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced `android_ripple` attribute documentation to clarify `PlatformColor` support and explain automatic color updates during system theme transitions.
  * Improved formatting and alignment of RippleConfig properties documentation for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reactnativecn/react-native-website/pull/1027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->