### PR TITLE
docs(cndocs): sync out-of-tree-platforms Fabric link + cnwebsite dep bump

### DIFF
--- a/cndocs/out-of-tree-platforms.md
+++ b/cndocs/out-of-tree-platforms.md
@@ -19,7 +19,7 @@ React Native 不仅适用于 Android 和 iOS 设备——我们的合作伙伴�
 
 ## 创建你自己的 React Native 平台
 
-目前，从零开始创建一个 React Native 平台的过程还没有非常完善的文档——新的架构（[Fabric](/blog/2018/06/14/state-of-react-native-2018)）旨在让平台维护更容易。
+目前，从零开始创建一个 React Native 平台的过程还没有非常完善的文档——新的架构（[Fabric](/architecture/fabric-renderer)）旨在让平台维护更容易。
 
 ### 打包
 

--- a/cnwebsite/package.json
+++ b/cnwebsite/package.json
@@ -53,7 +53,7 @@
     "@docusaurus/plugin-pwa": "3.10.1",
     "@docusaurus/preset-classic": "3.10.1",
     "@docusaurus/theme-mermaid": "3.10.1",
-    "docusaurus-plugin-copy-page-button": "^0.8.0",
+    "docusaurus-plugin-copy-page-button": "^0.8.1",
     "docusaurus-plugin-sass": "^0.2.6",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",


### PR DESCRIPTION
## 翻译同步 — 2026-06-07

本次同步上游 2 个新提交（`out-of-tree-platforms` Fabric 链接更新 + copy-page-button 插件升级）。

### 翻译文件变更

- **`cndocs/out-of-tree-platforms.md`**: 更新 Fabric 链接，从旧博客文章 `/blog/2018/06/14/state-of-react-native-2018` 改为 `/architecture/fabric-renderer`（与上游 #5114 一致）

### cnwebsite 配置同步

- **`cnwebsite/package.json`**: `docusaurus-plugin-copy-page-button` ^0.8.0 → ^0.8.1（修复 malformed icon，上游 #5115）

### 本轮候选情况

sync-translations.sh 列出 18 个候选文件：
- 8 个 stub 文件（已从 RN 移除的组件，CN 已同步为 danger 提示）— 跳过
- 9 个已同步文件（与 EN 无差异）— 跳过
- 1 个实际落差：`out-of-tree-platforms.md`（Fabric 链接）— 已修复

### 构建验证

`yarn --cwd cnwebsite build` ✅ 通过（73s），仅有版本化文档中已知的 HTML minifier 警告。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Fabric architecture reference links in platform development documentation.
  * Enhanced rnpm configuration documentation with clarifications on array parameters and their scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->