### PR TITLE
docs(cndocs): sync import style, code fences, and cnwebsite deps (2026-06-21)

### DIFF
--- a/cndocs/debugging-native-code.md
+++ b/cndocs/debugging-native-code.md
@@ -50,7 +50,7 @@ adb logcat "*:S" ReactNative:V ReactNativeJS:V YourModuleName:D
 
 在原生模块中，使用 `NSLog` 添加自定义日志：
 
-```objective-c
+```objectivec
 NSLog(@"YourModuleName: %@", message);
 ```
 

--- a/cndocs/document-nodes.md
+++ b/cndocs/document-nodes.md
@@ -6,7 +6,7 @@ title: 文档节点
 文档节点表示完整的原生视图树。使用原生导航的应用会为每个屏幕提供单独的文档节点。不使用原生导航的应用通常会为整个应用提供单个文档（类似于 Web 上的单页应用）。
 
 ```SnackPlayer ext=js&name=Document%20instance%20example
-import * as React from 'react';
+import {useEffect, useRef} from 'react';
 import {Text, TextInput, View} from 'react-native';
 
 function MyComponent(props) {
@@ -19,9 +19,9 @@ function MyComponent(props) {
 }
 
 export default function AccessingDocument() {
-  const ref = React.useRef(null);
+  const ref = useRef(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // 获取屏幕中的主文本输入框并在初始加载后聚焦它。
     const element = ref.current;
     const doc = element.ownerDocument;

--- a/cndocs/element-nodes.md
+++ b/cndocs/element-nodes.md
@@ -8,14 +8,14 @@ title: 元素节点
 它们通过 refs 由所有原生组件和许多内置组件提供：
 
 ```SnackPlayer ext=js&name=Element%20instances%20example
-import * as React from 'react';
-import { View, SafeAreaView, StyleSheet, Text } from 'react-native';
+import {useEffect, useRef, useState} from 'react';
+import {View, SafeAreaView, StyleSheet, Text} from 'react-native';
 
 const ViewWithRefs = () => {
-  const ref = React.useRef(null);
-  const [viewInfo, setViewInfo] = React.useState('');
+  const ref = useRef(null);
+  const [viewInfo, setViewInfo] = useState('');
 
-  React.useEffect(() => {
+  useEffect(() => {
     // `element` 是实现此处描述的接口的对象。
     const element = ref.current;
     const rect = JSON.stringify(element.getBoundingClientRect());

--- a/cndocs/text-nodes.md
+++ b/cndocs/text-nodes.md
@@ -6,14 +6,14 @@ title: 文本节点
 文本节点表示树中的原始文本内容（类似于 Web 上的 [`Text`](https://developer.mozilla.org/zh-CN/docs/Web/API/Text) 节点）。它们不能直接通过 `refs` 访问，但可以使用元素 refs 上的方法（如 [`childNodes`](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/childNodes)）来访问。
 
 ```SnackPlayer ext=js&name=Text%20instances%20example
-import * as React from 'react';
-import { SafeAreaView, StyleSheet, Text } from 'react-native';
+import {useEffect, useRef, useState} from 'react';
+import {SafeAreaView, StyleSheet, Text} from 'react-native';
 
 const TextWithRefs = () => {
-  const ref = React.useRef(null);
-  const [viewInfo, setViewInfo] = React.useState('');
+  const ref = useRef(null);
+  const [viewInfo, setViewInfo] = useState('');
 
-  React.useEffect(() => {
+  useEffect(() => {
     // `textElement` 是实现此处描述的接口的对象。
     const textElement = ref.current;
     const textNode = textElement.childNodes[0];

--- a/cndocs/timers.md
+++ b/cndocs/timers.md
@@ -33,7 +33,7 @@ title: 定时器
 
 应用可以通过以下代码来安排一个任务，使其在交互结束之后执行：
 
-```tsx
+```ts
 InteractionManager.runAfterInteractions(() => {
   // ...long-running synchronous task...
 });
@@ -49,7 +49,7 @@ InteractionManager.runAfterInteractions(() => {
 
 InteractionManager 还允许应用注册动画，在动画开始时创建一个交互“句柄”，然后在结束的时候清除它。
 
-```tsx
+```ts
 const handle = InteractionManager.createInteractionHandle();
 // run animation... (`runAfterInteractions` tasks are queued)
 // later, on animation completion:

--- a/cnwebsite/package.json
+++ b/cnwebsite/package.json
@@ -53,7 +53,7 @@
     "@docusaurus/plugin-pwa": "3.10.1",
     "@docusaurus/preset-classic": "3.10.1",
     "@docusaurus/theme-mermaid": "3.10.1",
-    "docusaurus-plugin-copy-page-button": "^0.8.1",
+    "docusaurus-plugin-copy-page-button": "^0.8.2",
     "docusaurus-plugin-sass": "^0.2.6",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
@@ -67,12 +67,12 @@
     "@react-native-website/lint-examples": "*",
     "@signalwire/docusaurus-plugin-llms-txt": "^1.2.2",
     "@types/google.analytics": "^0.0.46",
-    "@types/react": "^19.2.16",
+    "@types/react": "^19.2.17",
     "eslint": "^9.39.4",
     "glob": "^13.0.6",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.4",
     "remark-cli": "^12.0.1",
-    "sass": "1.100.0",
+    "sass": "1.101.0",
     "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Translation sync batch for 2026-06-21. Merged upstream changes and synced 5 CN docs files + cnwebsite dependency versions.

### Translation sync (5 files)

| File | Change |
|------|--------|
| `cndocs/document-nodes.md` | React import style: `import * as React` → destructured `import {useEffect, useRef}` |
| `cndocs/element-nodes.md` | React import style: `import * as React` → destructured `import {useEffect, useRef, useState}` |
| `cndocs/text-nodes.md` | React import style: `import * as React` → destructured `import {useEffect, useRef, useState}` |
| `cndocs/timers.md` | Code fence: `tsx` → `ts` (matching upstream) |
| `cndocs/debugging-native-code.md` | Code fence: `objective-c` → `objectivec` (matching upstream) |

### cnwebsite config sync

- `docusaurus-plugin-copy-page-button` ^0.8.1 → ^0.8.2
- `@types/react` ^19.2.16 → ^19.2.17
- `prettier` ^3.8.3 → ^3.8.4
- `sass` 1.100.0 → 1.101.0

### Upstream merge (10 commits)

Main upstream changes merged to `production`:
- Dependency bumps: dompurify, webpack-dev-server, @babel/core, launch-editor, ws
- Stylelint setup for website CSS
- 0.86 release blog post fix (duplicate Highlights anchor)
- AppJS 2026 conference talks link
- Lint deps updates

### Candidates skipped (already synced or false positives)

11 of 16 sync-script candidates were false positives:
- 6 removed-component stubs (checkbox, clipboard, datepickerandroid, datepickerios, imagepickerios, timepickerandroid) — already translated
- 2 stubs (segmentedcontrolios, statusbarios) — already translated
- 3 files with no structural drift (colors, custom-cxx-types, layout-measurements) — only translation differences

### Build verification

`yarn --cwd cnwebsite build` passes (89.75s). Pre-existing HTML minifier warnings in versioned docs (appregistry, linking) are unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed code syntax highlighting in iOS native code examples.
  * Updated React code examples to use modern hooks import patterns.

* **Chores**
  * Updated development dependencies to latest stable versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->