### PR TITLE
docs(cndocs): remove React.useState/useRef prefix in new-architecture docs

### DIFF
--- a/cndocs/the-new-architecture/custom-cxx-types.md
+++ b/cndocs/the-new-architecture/custom-cxx-types.md
@@ -173,8 +173,8 @@ First, we need to update the `App.tsx` file to use the new method from the Turbo
 
 ```diff title="App.tsx"
 // ...
-+ const [cubicSource, setCubicSource] = React.useState('')
-+ const [cubicRoot, setCubicRoot] = React.useState(0)
++ const [cubicSource, setCubicSource] = useState('')
++ const [cubicRoot, setCubicRoot] = useState(0)
   return (
     <SafeAreaView style={styles.container}>
       <View>
@@ -366,9 +366,9 @@ To test the code in the app, we have to modify the `App.tsx` file.
 2. Replace the body of the `App()` function with the following code:
 
 ```tsx title="App.tsx (App function body replacement)"
-const [street, setStreet] = React.useState('');
-const [num, setNum] = React.useState('');
-const [isValidAddress, setIsValidAddress] = React.useState<
+const [street, setStreet] = useState('');
+const [num, setNum] = useState('');
+const [isValidAddress, setIsValidAddress] = useState<
   boolean | null
 >(null);
 

--- a/cndocs/the-new-architecture/layout-measurements.md
+++ b/cndocs/the-new-architecture/layout-measurements.md
@@ -10,7 +10,7 @@ Typical code will look like this:
 
 ```tsx
 function AComponent(children) {
-  const targetRef = React.useRef(null)
+  const targetRef = useRef(null)
 
   useLayoutEffect(() => {
     targetRef.current?.measure((x, y, width, height, pageX, pageY) => {


### PR DESCRIPTION
## Summary

Sync 2 `cndocs/` files with upstream — remove `React.useState`/`React.useRef` prefix to match the React 17+ JSX transform pattern used upstream.

### Translation files changed

| File | Change |
|------|--------|
| `cndocs/the-new-architecture/custom-cxx-types.md` | `React.useState` → `useState` (5 occurrences) |
| `cndocs/the-new-architecture/layout-measurements.md` | `React.useRef` → `ref` (1 occurrence) |

### Website config / deps sync

No `cnwebsite/` config or dependency changes needed this batch. Upstream changes since PR #1035 were limited to `website/` footer link reorganization and styling tweaks — CN website has its own independent footer structure.

### False positives (already synced, no changes needed)

8 stub files (`checkbox`, `clipboard`, `datepickerandroid`, `datepickerios`, `imagepickerios`, `segmentedcontrolios`, `statusbarios`, `timepickerandroid`) are already properly translated CN versions of "Removed from React Native" notices. `colors.md` is also already fully translated — differences are only in translated prose, not structure or code.

### Notes

- These files will still appear in `sync-translations.sh` output until this PR merges to `production`, because the script compares upstream timestamps against `production`.
- No `website/` → `cnwebsite/` config sync needed: upstream's recent `docusaurus.config.ts` changes (copyright text, footer link reorganization) don't apply to CN's independent footer/branding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example code in the custom C++ types guide to use direct React hooks and reflect current state handling for the sample app.
  * Expanded the cubic root example so it includes input handling and displays the computed result in the UI.
  * Refined the structured address example code to match the latest hook usage and state setup.
  * Updated the layout measurements guide to use direct `useRef` hook usage in the sample snippet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->