### PR TITLE
docs(cndocs): sync removed API admonitions

### DIFF
--- a/cndocs/checkbox.md
+++ b/cndocs/checkbox.md
@@ -3,6 +3,6 @@ id: checkbox
 title: '❌ CheckBox'
 ---
 
-:::danger 已从 React Native 中移除
+:::danger[已从 React Native 中移除]
 请使用[社区提供的替代方案](https://reactnative.directory/?search=checkbox)。
 :::

--- a/cndocs/clipboard.md
+++ b/cndocs/clipboard.md
@@ -3,6 +3,6 @@ id: clipboard
 title: '❌ Clipboard'
 ---
 
-:::danger 已从 React Native 中移除
+:::danger[已从 React Native 中移除]
 请使用[社区提供的替代方案](https://reactnative.directory/?search=clipboard)。
 :::

--- a/cndocs/datepickerandroid.md
+++ b/cndocs/datepickerandroid.md
@@ -3,6 +3,6 @@ id: datepickerandroid
 title: '❌ DatePickerAndroid'
 ---
 
-:::danger 已从 React Native 移除
+:::danger[已从 React Native 移除]
 请改用[社区包](https://reactnative.directory/?search=datepicker)。
 :::

--- a/cndocs/datepickerios.md
+++ b/cndocs/datepickerios.md
@@ -3,6 +3,6 @@ id: datepickerios
 title: '❌ DatePickerIOS'
 ---
 
-:::danger 已从 React Native 中移除
+:::danger[已从 React Native 中移除]
 请改用[社区包](https://reactnative.directory/?search=datepicker)。
 :::

--- a/cndocs/imagepickerios.md
+++ b/cndocs/imagepickerios.md
@@ -3,6 +3,6 @@ id: imagepickerios
 title: '❌ ImagePickerIOS'
 ---
 
-:::danger 已从 React Native 中移除
+:::danger[已从 React Native 中移除]
 请使用[社区包](https://reactnative.directory/?search=image+picker)替代。
 :::

--- a/cndocs/segmentedcontrolios.md
+++ b/cndocs/segmentedcontrolios.md
@@ -3,7 +3,7 @@ id: segmentedcontrolios
 title: '❌ SegmentedControlIOS'
 ---
 
-:::danger 已从 React Native 中移除
+:::danger[已从 React Native 中移除]
 请使用[社区包](https://reactnative.directory/?search=segmentedcontrol)替代。
 :::
 

--- a/cndocs/statusbarios.md
+++ b/cndocs/statusbarios.md
@@ -3,7 +3,7 @@ id: statusbarios
 title: '❌ StatusBarIOS'
 ---
 
-:::danger 已从 React Native 中移除
+:::danger[已从 React Native 中移除]
 请使用 [`StatusBar`](statusbar.md) 来操作状态栏。
 :::
 

--- a/cndocs/timepickerandroid.md
+++ b/cndocs/timepickerandroid.md
@@ -3,6 +3,6 @@ id: timepickerandroid
 title: '❌ TimePickerAndroid'
 ---
 
-:::danger 已从 React Native 中移除
+:::danger[已从 React Native 中移除]
 请使用[社区包](https://reactnative.directory/?search=timepicker)替代。
 :::


### PR DESCRIPTION
## Summary

- 同步 8 个已从 React Native 移除的 API 页面：
  - `checkbox.md`
  - `clipboard.md`
  - `datepickerandroid.md`
  - `datepickerios.md`
  - `imagepickerios.md`
  - `segmentedcontrolios.md`
  - `statusbarios.md`
  - `timepickerandroid.md`
- 将这些页面的 `danger` admonition 标题更新为 Docusaurus 当前使用的方括号语法，保持与英文源文档结构一致。
- `colors.md` 经逐项核验后无需修改：英文侧最近两次变更仅修正英文措辞，现有中文内容已经表达了修正后的含义，因此作为时间戳误报跳过。

## website → cnwebsite sync

- 本次上游合并只更新了根目录 `yarn.lock` 中的 `websocket-driver`（已直接合并并推送到 `production`）。
- `website/package.json`、`docusaurus.config.ts`、`sidebars.ts`、`tsconfig.json` 在本次上游范围内没有配置或依赖变更，因此本 PR 无需修改 `cnwebsite/`。
- 已确认 `website` 与 `cnwebsite` 的共享依赖版本一致；`cnwebsite` 仍保留 `docs.path: '../cndocs'`、中文侧边栏和 CN workspace 配置。

## Verification

- `git diff --check`
- `yarn --cwd cnwebsite build`（通过；仅有既存的版本化文档链接及 HTML minifier warnings）

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reactnativecn/codesmith/react-native-website/pr/1039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787053123&installation_id=146037136&pr_number=1039&repository=reactnativecn%2Freact-native-website&return_to=https%3A%2F%2Fgithub.com%2Freactnativecn%2Freact-native-website%2Fpull%2F1039&signature=aae9753ef5f9e42f6f7d97eb7380f03015ab52a4b886a544d6955c6775e2bc75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved removal notices for deprecated React Native components.
  - Standardized warning callouts with clear Chinese labels.
  - Preserved existing replacement guidance and links to recommended alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->