### PR TITLE
docs(cndocs): sync images iOS asset catalog section

### DIFF
--- a/cndocs/images.md
+++ b/cndocs/images.md
@@ -65,6 +65,21 @@ const icon = this.props.active
 
 请注意：通过这种方式引用的图片资源包含图片的尺寸（宽度，高度）信息，如果你需要动态缩放图片（例如，通过 flex），你可能必须手动在 style 属性设置`{ width: null, height: null }`。
 
+### iOS 中使用 Asset Catalog 打包图片
+
+默认情况下，打包工具会将每张通过 `require` 引入的图片及其对应的 `@2x` / `@3x` 变体，作为独立文件放到 iOS 应用中，和 JavaScript bundle 放在同一目录下。你也可以在 iOS 平台上改为编译到 [Asset Catalog](https://developer.apple.com/documentation/xcode/managing-assets-with-asset-catalogs) 中，让系统只下发设备所需的 scale。
+
+要开启此特性，请在应用的 `Info.plist` 中将 `RCTUseAssetCatalog` 设置为 `true`：
+
+```xml
+<key>RCTUseAssetCatalog</key>
+<true/>
+```
+
+开启后，iOS 构建脚本会在构建时将打包图片编译到 `RNAssets.bundle` 的 asset catalog 中。`require('./my-icon.png')` 的引用方式可以保持不变，无需改动 Xcode 工程。
+
+修改该设置后，请记得清理工程并重新构建。
+
 ## 静态的非图片资源
 
 上面描述的`require`语法也可以用来静态地加载你项目中的声音、视频或者文档文件。大多数常见文件类型都支持，包括`.mp3`, `.wav`, `.mp4`, `.mov`, `.html`, `.pdf`等。完整列表请看 [bundler defaults](https://github.com/facebook/metro/blob/main/packages/metro-config/src/defaults/defaults.js#L16-L51)。


### PR DESCRIPTION
## 概要
- 将 `cndocs/images.md` 与上游 `docs/images.md` 的新变更对齐：补齐 iOS 资产目录（Asset Catalog）相关说明。
- 本次实际编辑文件：
  - `cndocs/images.md`

## 变更详情
- 新增章节：
  - **iOS 中使用 Asset Catalog 打包图片**，翻译了上游新增内容，包含：
    - 默认行为（将 `@2x`/`@3x` 图片与原图打包为松散文件）
    - `Info.plist` 中启用 `RCTUseAssetCatalog` 的示例
    - 启用后的构建行为和 `RNAssets.bundle` 说明
    - 清理并重建建议

## 上游配置同步
- 本次上游合并（`production <- upstream/main`）后核对了 `website/` 与 `cnwebsite/` 侧的同步项，未发现需要落地到 CN 的非 CN 定制差异化配置变更。
- 本次未修改 `cnwebsite` 站点配置/依赖文件（未触发 `website/docusaurus.config.ts` 的可同步差异到 CN）：
  - 未改动 `cnwebsite/package.json`
  - 未改动 `cnwebsite/docusaurus.config.ts`

## 验证
- `scripts/sync-translations.sh` 命中候选：`cndocs/colors.md`, `cndocs/images.md`
  - `colors.md` 仅为脚本陈旧候选（EN 自身无新增内容），确认已是已同步状态，故未重复修改。
  - `images.md` 进行实际同步并完成翻译补齐。
- 执行：`yarn --cwd cnwebsite build`
  - 构建成功（有少量已知/既有警告，主要是历史版文档的链接与 HTML minifier 提示）。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reactnativecn/codesmith/react-native-website/pr/1040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787658348&installation_model_id=426977&pr_number=1040&repository=reactnativecn%2Freact-native-website&return_to=https%3A%2F%2Fgithub.com%2Freactnativecn%2Freact-native-website%2Fpull%2F1040&signature=f67a61007c7b83c0016e502ce72931f9e619786cb5d105d5deefc16fca583f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring iOS image assets to use the Asset Catalog.
  * Documented the required `Info.plist` setting and expected handling of `@2x` and `@3x` image variants.
  * Added instructions to clean and rebuild the project after enabling the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->