### PR TITLE
docs(cndocs): 同步最新上游 API 示例

### DIFF
--- a/cndocs/animated.md
+++ b/cndocs/animated.md
@@ -188,15 +188,15 @@ Animated.timing({}).start(({finished}) => {
 例如在横向滚动中，将 `event.nativeEvent.contentOffset.x` 映射到 `scrollX`（一个 `Animated.Value`）：
 
 ```tsx
- onScroll={Animated.event(
-   // scrollX = e.nativeEvent.contentOffset.x
-   [{nativeEvent: {
-        contentOffset: {
-          x: scrollX
-        }
-      }
-    }]
- )}
+onScroll={Animated.event(
+  // scrollX = e.nativeEvent.contentOffset.x
+  [{
+    nativeEvent: {
+      contentOffset: {x: scrollX},
+    },
+  }],
+  {useNativeDriver: true},
+)}
 ```
 
 ---

--- a/cndocs/animatedvaluexy.md
+++ b/cndocs/animatedvaluexy.md
@@ -17,13 +17,16 @@ const DraggableView = () => {
 
   const panResponder = PanResponder.create({
     onStartShouldSetPanResponder: () => true,
-    onPanResponderMove: Animated.event([
-      null,
-      {
-        dx: pan.x, // x,y are Animated.Value
-        dy: pan.y,
-      },
-    ]),
+    onPanResponderMove: Animated.event(
+      [
+        null,
+        {
+          dx: pan.x, // x,y are Animated.Value
+          dy: pan.y,
+        },
+      ],
+      {useNativeDriver: false},
+    ),
     onPanResponderRelease: () => {
       Animated.spring(
         pan, // Auto-multiplexed

--- a/cndocs/animations.md
+++ b/cndocs/animations.md
@@ -293,15 +293,15 @@ Animated.timing(opacity, {
 例如，在使用水平滚动手势时，您可以执行以下操作，以便将“event.nativeEvent.contentOffset.x”映射到“scrollX”（“Animated.Value”）：
 
 ```tsx
- onScroll={Animated.event(
-   // scrollX = e.nativeEvent.contentOffset.x
-   [{nativeEvent: {
-        contentOffset: {
-          x: scrollX
-        }
-      }
-    }]
- )}
+onScroll={Animated.event(
+  // scrollX = e.nativeEvent.contentOffset.x
+  [{
+    nativeEvent: {
+      contentOffset: {x: scrollX},
+    },
+  }],
+  {useNativeDriver: true},
+)}
 ```
 
 以下示例实现了水平滚动轮播，其中滚动位置指示器使用“ScrollView”中使用的“Animated.event”进行动画处理
@@ -338,15 +338,18 @@ const App = () => {
             horizontal={true}
             pagingEnabled
             showsHorizontalScrollIndicator={false}
-            onScroll={Animated.event([
-              {
-                nativeEvent: {
-                  contentOffset: {
-                    x: scrollX,
+            onScroll={Animated.event(
+              [
+                {
+                  nativeEvent: {
+                    contentOffset: {
+                      x: scrollX,
+                    },
                   },
                 },
-              },
-            ])}
+              ],
+              {useNativeDriver: true},
+            )}
             scrollEventThrottle={1}>
             {images.map((image, imageIndex) => {
               return (
@@ -459,7 +462,9 @@ const App = () => {
   const panResponder = useRef(
     PanResponder.create({
       onMoveShouldSetPanResponder: () => true,
-      onPanResponderMove: Animated.event([null, {dx: pan.x, dy: pan.y}]),
+      onPanResponderMove: Animated.event([null, {dx: pan.x, dy: pan.y}], {
+        useNativeDriver: false,
+      }),
       onPanResponderRelease: () => {
         Animated.spring(pan, {
           toValue: {x: 0, y: 0},

--- a/cndocs/appstate.md
+++ b/cndocs/appstate.md
@@ -38,7 +38,7 @@ const AppStateExample = () => {
   useEffect(() => {
     const subscription = AppState.addEventListener('change', nextAppState => {
       if (
-        appState.current.match(/inactive|background/) &&
+        appState.current?.match(/inactive|background/) &&
         nextAppState === 'active'
       ) {
         console.log('App has come to the foreground!');

--- a/cndocs/dimensions.md
+++ b/cndocs/dimensions.md
@@ -26,9 +26,14 @@ const windowHeight = Dimensions.get('window').height;
 
 ## 示例
 
-```SnackPlayer name=Dimensions%20Example
+```SnackPlayer name=Dimensions%20Example&ext=tsx
 import {useState, useEffect} from 'react';
-import {StyleSheet, Text, Dimensions} from 'react-native';
+import {
+  StyleSheet,
+  Text,
+  Dimensions,
+  type DimensionsPayload,
+} from 'react-native';
 import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const windowDimensions = Dimensions.get('window');
@@ -43,8 +48,10 @@ const App = () => {
   useEffect(() => {
     const subscription = Dimensions.addEventListener(
       'change',
-      ({window, screen}) => {
-        setDimensions({window, screen});
+      ({window, screen}: DimensionsPayload) => {
+        if (window && screen) {
+          setDimensions({window, screen});
+        }
       },
     );
     return () => subscription?.remove();

--- a/cndocs/drawerlayoutandroid.md
+++ b/cndocs/drawerlayoutandroid.md
@@ -95,8 +95,12 @@ import {
   View,
 } from 'react-native';
 
+type DrawerLayoutAndroidInstance = React.ComponentRef<
+  typeof DrawerLayoutAndroid
+>;
+
 const App = () => {
-  const drawer = useRef<DrawerLayoutAndroid>(null);
+  const drawer = useRef<DrawerLayoutAndroidInstance>(null);
   const [drawerPosition, setDrawerPosition] = useState<'left' | 'right'>(
     'left',
   );

--- a/cndocs/flexbox.md
+++ b/cndocs/flexbox.md
@@ -985,12 +985,17 @@ export default AlignSelfLayout;
 
 ```SnackPlayer name=Align%20Self&ext=tsx
 import {useState} from 'react';
-import {View, TouchableOpacity, Text, StyleSheet} from 'react-native';
+import {
+  View,
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+  type ViewStyle,
+} from 'react-native';
 import type {PropsWithChildren} from 'react';
-import type {FlexAlignType} from 'react-native';
 
 const AlignSelfLayout = () => {
-  const [alignSelf, setAlignSelf] = useState<FlexAlignType>('stretch');
+  const [alignSelf, setAlignSelf] = useState<ViewStyle['alignSelf']>('stretch');
 
   return (
     <PreviewLayout
@@ -1017,9 +1022,9 @@ const AlignSelfLayout = () => {
 
 type PreviewLayoutProps = PropsWithChildren<{
   label: string;
-  values: FlexAlignType[];
-  selectedValue: string;
-  setSelectedValue: (value: FlexAlignType) => void;
+  values: ViewStyle['alignSelf'][];
+  selectedValue: ViewStyle['alignSelf'];
+  setSelectedValue: (value: ViewStyle['alignSelf']) => void;
 }>;
 
 const PreviewLayout = ({

--- a/cndocs/improvingux.md
+++ b/cndocs/improvingux.md
@@ -125,8 +125,10 @@ import {
   StyleSheet,
 } from 'react-native';
 
+type TextInputInstance = React.ComponentRef<typeof TextInput>;
+
 const App = () => {
-  const emailInput = useRef<TextInput>(null);
+  const emailInput = useRef<TextInputInstance>(null);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
 
@@ -325,8 +327,10 @@ import {
   StyleSheet,
 } from 'react-native';
 
+type TextInputInstance = React.ComponentRef<typeof TextInput>;
+
 const App = () => {
-  const emailInput = useRef<TextInput>(null);
+  const emailInput = useRef<TextInputInstance>(null);
   const [email, setEmail] = useState('');
 
   const submit = () => {

--- a/cndocs/layout-props.md
+++ b/cndocs/layout-props.md
@@ -197,8 +197,7 @@ import {
   StyleSheet,
   Text,
   View,
-  FlexAlignType,
-  FlexStyle,
+  ViewStyle,
 } from 'react-native';
 import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
@@ -217,7 +216,7 @@ const App = () => {
     alignItems: alignItemsArr[alignItems],
     direction: directions[direction],
     flexWrap: wraps[wrap],
-  } as FlexStyle;
+  };
 
   const changeSetting = (
     value: number,
@@ -307,29 +306,29 @@ const App = () => {
   );
 };
 
-const flexDirections = [
+const flexDirections: ViewStyle['flexDirection'][] = [
   'row',
   'row-reverse',
   'column',
   'column-reverse',
-] as FlexStyle['flexDirection'][];
-const justifyContents = [
+];
+const justifyContents: ViewStyle['justifyContent'][] = [
   'flex-start',
   'flex-end',
   'center',
   'space-between',
   'space-around',
   'space-evenly',
-] as FlexStyle['justifyContent'][];
-const alignItemsArr = [
+];
+const alignItemsArr: ViewStyle['alignItems'][] = [
   'flex-start',
   'flex-end',
   'center',
   'stretch',
   'baseline',
-] as FlexAlignType[];
-const wraps = ['nowrap', 'wrap', 'wrap-reverse'];
-const directions = ['inherit', 'ltr', 'rtl'];
+];
+const wraps: ViewStyle['flexWrap'][] = ['nowrap', 'wrap', 'wrap-reverse'];
+const directions: ViewStyle['direction'][] = ['inherit', 'ltr', 'rtl'];
 
 const styles = StyleSheet.create({
   container: {

--- a/cndocs/legacy/direct-manipulation.md
+++ b/cndocs/legacy/direct-manipulation.md
@@ -136,13 +136,16 @@ export default App;
 <TabItem value="typescript">
 
 ```SnackPlayer name=Forwarding%20setNativeProps&ext=tsx
+import {forwardRef, ElementRef} from 'react';
 import {Text, TouchableOpacity, View} from 'react-native';
 
-const MyButton = React.forwardRef<View, {label: string}>((props, ref) => (
-  <View {...props} ref={ref} style={{marginTop: 50}}>
-    <Text>{props.label}</Text>
-  </View>
-));
+const MyButton = forwardRef<ElementRef<typeof View>, {label: string}>(
+  (props, ref) => (
+    <View {...props} ref={ref} style={{marginTop: 50}}>
+      <Text>{props.label}</Text>
+    </View>
+  ),
+);
 
 const App = () => (
   <TouchableOpacity>
@@ -224,8 +227,10 @@ import {
   View,
 } from 'react-native';
 
+type TextInputInstance = React.ComponentRef<typeof TextInput>;
+
 const App = () => {
-  const inputRef = useRef<TextInput>(null);
+  const inputRef = useRef<TextInputInstance>(null);
   const editText = useCallback(() => {
     inputRef.current?.setNativeProps({text: 'Edited Text'});
   }, []);
@@ -374,9 +379,12 @@ type Measurements = {
   height: number;
 };
 
+type TextInstance = React.ComponentRef<typeof Text>;
+type ViewInstance = React.ComponentRef<typeof View>;
+
 const App = () => {
-  const textContainerRef = useRef<View>(null);
-  const textRef = useRef<Text>(null);
+  const textContainerRef = useRef<ViewInstance>(null);
+  const textRef = useRef<TextInstance>(null);
   const [measure, setMeasure] = useState<Measurements | null>(null);
 
   useEffect(() => {

--- a/cndocs/linking.md
+++ b/cndocs/linking.md
@@ -340,7 +340,7 @@ const useInitialURL = () => {
 
       // The setTimeout is just for testing purpose
       setTimeout(() => {
-        setUrl(initialUrl);
+        setUrl(initialUrl ?? null);
         setProcessing(false);
       }, 1000);
     };
@@ -394,7 +394,7 @@ const useInitialURL = () => {
 
       // The setTimeout is just for testing purpose
       setTimeout(() => {
-        setUrl(initialUrl);
+        setUrl(initialUrl ?? null);
         setProcessing(false);
       }, 1000);
     };

--- a/cndocs/panresponder.md
+++ b/cndocs/panresponder.md
@@ -97,7 +97,9 @@ const App = () => {
   const panResponder = useRef(
     PanResponder.create({
       onMoveShouldSetPanResponder: () => true,
-      onPanResponderMove: Animated.event([null, {dx: pan.x, dy: pan.y}]),
+      onPanResponderMove: Animated.event([null, {dx: pan.x, dy: pan.y}], {
+        useNativeDriver: false,
+      }),
       onPanResponderRelease: () => {
         pan.extractOffset();
       },

--- a/cndocs/progressbarandroid.md
+++ b/cndocs/progressbarandroid.md
@@ -19,15 +19,19 @@ const App = () => {
     <View style={styles.container}>
       <View style={styles.example}>
         <Text>Circle Progress Indicator</Text>
-        <ProgressBarAndroid />
+        <ProgressBarAndroid indeterminate styleAttr="Normal" />
       </View>
       <View style={styles.example}>
         <Text>Horizontal Progress Indicator</Text>
-        <ProgressBarAndroid styleAttr="Horizontal" />
+        <ProgressBarAndroid indeterminate styleAttr="Horizontal" />
       </View>
       <View style={styles.example}>
         <Text>Colored Progress Indicator</Text>
-        <ProgressBarAndroid styleAttr="Horizontal" color="#2196F3" />
+        <ProgressBarAndroid
+          indeterminate
+          styleAttr="Horizontal"
+          color="#2196F3"
+        />
       </View>
       <View style={styles.example}>
         <Text>Fixed Progress Value</Text>

--- a/cndocs/statusbar.md
+++ b/cndocs/statusbar.md
@@ -26,7 +26,7 @@ import {
 } from 'react-native';
 import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
-const STYLES = ['default', 'dark-content', 'light-content'];
+const STYLES = ['default', 'auto', 'dark-content', 'light-content'];
 const TRANSITIONS = ['fade', 'slide', 'none'];
 
 const App = () => {
@@ -134,7 +134,7 @@ import {
 } from 'react-native';
 import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
-const STYLES = ['default', 'dark-content', 'light-content'] as const;
+const STYLES = ['default', 'auto', 'dark-content', 'light-content'] as const;
 const TRANSITIONS = ['fade', 'slide', 'none'] as const;
 
 const App = () => {
@@ -409,8 +409,9 @@ iOS 上状态栏的过渡动画类型。
 
 **常量：**
 
-| 值                | 类型   | 描述                                         |
-| ----------------- | ------ | -------------------------------------------- |
-| `'default'`       | string | 默认状态栏样式（iOS 为深色，Android 为浅色） |
-| `'light-content'` | string | 白色文字和图标                               |
-| `'dark-content'`  | string | 深色文字和图标（Android 上需要 API>=23）     |
+| 值                | 类型   | 描述                                                                                   |
+| ----------------- | ------ | -------------------------------------------------------------------------------------- |
+| `'default'`       | string | 默认状态栏样式（Android 为浅色，iOS 为深色）                                           |
+| `'auto'`          | string | 根据当前配色方案自动选择 `light-content` 或 `dark-content`，并会在配色方案变化时更新。 |
+| `'light-content'` | string | 白色文字和图标                                                                         |
+| `'dark-content'`  | string | 深色文字和图标（Android 上需要 API>=23）                                               |

--- a/cndocs/stylesheet.md
+++ b/cndocs/stylesheet.md
@@ -60,7 +60,7 @@ static compose(style1: Object, style2: Object): Object | Object[];
 
 将两个样式组合在一起，使得 `style2` 会覆盖 `style1` 中的任何样式。如果其中任何一个样式为 falsy，则直接返回另一个，不会分配数组，从而节省内存分配并保持 PureComponent 检查的引用相等性。
 
-```SnackPlayer name=Compose
+```SnackPlayer name=Compose&ext=js
 import {StyleSheet, Text} from 'react-native';
 import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 

--- a/cndocs/text-style-props.md
+++ b/cndocs/text-style-props.md
@@ -27,7 +27,6 @@ import {SafeAreaView, SafeAreaProvider} from 'react-native-safe-area-context';
 
 const fontStyles = ['normal', 'italic'];
 const fontVariants = [
-  undefined,
   'small-caps',
   'oldstyle-nums',
   'lining-nums',
@@ -628,7 +627,7 @@ const CustomSlider = ({
 
 type CustomPickerProps = {
   label: string;
-  data?: ArrayLike<any> | null;
+  data?: ArrayLike<string> | undefined;
   currentIndex: number;
   onSelected: (index: number) => void;
 };
@@ -676,7 +675,6 @@ const CustomPicker = ({
 
 const fontStyles = ['normal', 'italic'];
 const fontVariants = [
-  undefined,
   'small-caps',
   'oldstyle-nums',
   'lining-nums',

--- a/cndocs/the-new-architecture/direct-manipulation.md
+++ b/cndocs/the-new-architecture/direct-manipulation.md
@@ -82,8 +82,10 @@ import {
   View,
 } from 'react-native';
 
+type TextInputInstance = React.ComponentRef<typeof TextInput>;
+
 const App = () => {
-  const inputRef = useRef<TextInput>(null);
+  const inputRef = useRef<TextInputInstance>(null);
   const editText = useCallback(() => {
     inputRef.current?.setNativeProps({text: 'Edited Text'});
   }, []);

--- a/cndocs/view-style-props.md
+++ b/cndocs/view-style-props.md
@@ -117,6 +117,67 @@ export default App;
 
 ---
 
+### `backgroundPosition`
+
+控制背景渐变在视图内部的位置。当设置了 `backgroundImage` 时，可用它偏移或居中渐变，而不是让渐变填满整个区域。
+
+```tsx
+<View
+  style={{
+    backgroundImage: 'radial-gradient(circle, #ff6b6b, #4ecdc4)',
+    backgroundPosition: 'center',
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: '50px 50px',
+  }}
+/>
+```
+
+| 类型                                                                            |
+| ------------------------------------------------------------------------------- |
+| string \| 对象数组 `{top: string, left: string, right: string, bottom: string}` |
+
+---
+
+### `backgroundRepeat`
+
+控制背景渐变是否以及如何重复。它与 `backgroundImage` 配合使用，以平铺视图中的渐变。
+
+```tsx
+<View
+  style={{
+    backgroundImage: 'linear-gradient(45deg, #ff6b6b, #4ecdc4)',
+    backgroundRepeat: 'repeat',
+    backgroundSize: '20px 20px',
+  }}
+/>
+```
+
+| 类型                                                                                       |
+| ------------------------------------------------------------------------------------------ |
+| enum(`'repeat'`, `'space'`, `'round'`, `'no-repeat'`) \| 对象数组 `{x: string, y: string}` |
+
+---
+
+### `backgroundSize`
+
+控制背景渐变的尺寸。当设置了 `backgroundImage` 且渐变默认不应填满整个视图时，此属性尤其有用。
+
+```tsx
+<View
+  style={{
+    backgroundImage: 'linear-gradient(90deg, #a8edea, #fed6e3)',
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: '100px 100px',
+  }}
+/>
+```
+
+| 类型                                        |
+| ------------------------------------------- |
+| string \| 对象数组 `{x: number, y: number}` |
+
+---
+
 ### `borderBottomColor`
 
 | 类型               |

--- a/cnwebsite/package.json
+++ b/cnwebsite/package.json
@@ -67,7 +67,7 @@
     "@react-native-website/lint-examples": "*",
     "@signalwire/docusaurus-plugin-llms-txt": "^1.2.2",
     "@types/google.analytics": "^0.0.46",
-    "@types/react": "^19.2.17",
+    "@types/react": "19.2.17",
     "eslint": "^9.39.4",
     "glob": "^13.0.6",
     "prettier": "^3.9.6",


### PR DESCRIPTION
## 概要

已将 upstream/main 合并并推送到 `production`（`50923642f2`），随后同步实际落后的中文文档。

### 文档同步

- 动画与交互示例：`animated`、`animatedvaluexy`、`animations`、`panresponder` 增加/校正 `useNativeDriver` 配置。
- API/TypeScript 示例：`appstate`、`dimensions`、`drawerlayoutandroid`、`flexbox`、`improvingux`、`layout-props`、`legacy/direct-manipulation`、`linking`、`progressbarandroid`、`stylesheet`、`text-style-props`、`the-new-architecture/direct-manipulation`。
- `statusbar`：增加 `auto` 样式并补全中文类型说明。
- `view-style-props`：新增 `backgroundPosition`、`backgroundRepeat`、`backgroundSize` 中文说明与示例。

### cnwebsite 同步

- 对齐本次上游 `website/package.json` 的 `@types/react` 精确版本约束（移除 CN 配置中的 caret）。
- 未复制 CN 特有配置；`docs.path` 和中文侧边栏保持不变。

### 已核验但未改动

`colors` 与 `the-new-architecture/fabric-component-native-commands` 没有本次上游文档 diff；`pure-cxx-modules`、`turbo-native-modules` 的上游变动仅涉及其 MDX 动态版本命令，CN 对应页面维持既有静态 shell 命令，未进行不必要重写。

## 验证

- `npx --yes yarn@1.22.22 install --frozen-lockfile`
- `npx --yes yarn@1.22.22 eslint <18 个改动的 cndocs 文件>`
- `npx --yes yarn@1.22.22 --cwd cnwebsite build`（通过；仍有既存版本化文档链接/HTML minifier 警告）

未引入 Expo-first 内容。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reactnativecn/codesmith/react-native-website/pr/1043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791299958&installation_model_id=426977&pr_number=1043&repository=reactnativecn%2Freact-native-website&return_to=https%3A%2F%2Fgithub.com%2Freactnativecn%2Freact-native-website%2Fpull%2F1043&signature=1c1cceaf98efba627661204f8d044e4c1a3807286eabc6a176cc91a7e0101a65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for `backgroundPosition`, `backgroundRepeat`, and `backgroundSize` View style properties, including usage examples and accepted values.
  * Documented the `auto` StatusBar style option for automatic light/dark appearance updates.

* **Documentation**
  * Updated animation examples with explicit native-driver settings.
  * Improved TypeScript examples and ref typing across layout, input, gesture, and direct-manipulation guides.
  * Clarified examples for app state, dimensions, progress indicators, linking, and text styles.
  * Added safer handling for nullable values in applicable examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->